### PR TITLE
grafana-bridge in podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+MAINTAINER "Jan-Frode Myklebust <janfrode@tanso.net>"
+
+RUN yum -y install python38
+RUN yum clean all
+RUN pip3 install cherrypy
+RUN mkdir /opt/grafanabridge
+COPY zimonGrafanaIntf.py /opt/grafanabridge/zimonGrafanaIntf.py
+COPY queryHandler /opt/grafanabridge/queryHandler
+
+ARG ZSERVER
+ENV ZSERVER=$zserver
+
+EXPOSE 4242/tcp
+
+CMD ["sh", "-c", "/usr/bin/python3 /opt/grafanabridge/zimonGrafanaIntf.py -s $ZSERVER"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ RUN mkdir /opt/grafanabridge
 COPY zimonGrafanaIntf.py /opt/grafanabridge/zimonGrafanaIntf.py
 COPY queryHandler /opt/grafanabridge/queryHandler
 
-ARG ZSERVER
-ENV ZSERVER=$zserver
+ENV SERVER=127.0.0.1
+ENV SERVERPORT=9084
+ENV LOGFILE=/tmp/zserver.log
+ENV LOGLEVEL=20
+ENV PORT=4242
 
 EXPOSE 4242/tcp
 
@@ -20,4 +23,4 @@ USER grafanabridge
 
 WORKDIR /tmp
 
-CMD ["sh", "-c", "/usr/bin/python3 /opt/grafanabridge/zimonGrafanaIntf.py -s $ZSERVER"]
+CMD ["sh", "-c", "/usr/bin/python3 /opt/grafanabridge/zimonGrafanaIntf.py -s $SERVER -l $LOGFILE -c $LOGLEVEL -p $PORT"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,10 @@ ENV ZSERVER=$zserver
 
 EXPOSE 4242/tcp
 
+RUN groupadd -g 63719 grafanabridge
+RUN useradd -g 63719 -l -M -s /bin/false -u 63719 grafanabridge
+USER grafanabridge
+
+WORKDIR /tmp
+
 CMD ["sh", "-c", "/usr/bin/python3 /opt/grafanabridge/zimonGrafanaIntf.py -s $ZSERVER"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /opt/grafanabridge
 COPY zimonGrafanaIntf.py /opt/grafanabridge/zimonGrafanaIntf.py
 COPY queryHandler /opt/grafanabridge/queryHandler
 
-ENV SERVER=127.0.0.1
+ENV SERVER=zimoncollector
 ENV SERVERPORT=9084
 ENV LOGFILE=/tmp/zserver.log
 ENV LOGLEVEL=20

--- a/podman.md
+++ b/podman.md
@@ -7,13 +7,13 @@ The ***IBM Spectrum Scale bridge for Grafana*** can be built as a podman contain
 I've pushed x86_64 and ppc64le images to the dockerhub. The "lastest" tag is for x86_64, and "ppc64le" for, eh.. ppc64le. To launch the container on the same node as is running the ZimonCollector, I would suggest using "host" networking. Then it will have access to the ZimonCollector which is by default only listening on 127.0.0.1:
 
 ```shell
-# podman run --net host -it janfrode/grafana-bridge:latest
+# podman run --net host --add-host=zimoncollector:127.0.0.1 -it janfrode/grafana-bridge:latest
 ```
 
 Or on POWER (f.ex. on the ESS EMS):
 
 ```shell
-# podman run --net host -it janfrode/grafana-bridge:ppc64le
+# podman run --net host --add-host=zimoncollector:127.0.0.1 -it janfrode/grafana-bridge:ppc64le
 ```
 
 If running somewhere else than on the ZimonCollector host, you need to tell it the IP-address to connect to using SERVER environment setting, and also expose the bridge ports:
@@ -43,7 +43,7 @@ The grafana-bridge container can be run as a systemd service by first starting i
 
 
 ```shell
-# podman run -d --net host --name grafana-bridge -it janfrode/grafana-bridge:latest
+# podman run -d --net host --add-host=zimoncollector:127.0.0.1 --name grafana-bridge -it janfrode/grafana-bridge:latest
 ```
 
 Then kill it:

--- a/podman.md
+++ b/podman.md
@@ -1,0 +1,20 @@
+The ***IBM Spectrum Scale bridge for Grafana*** can be built as a podman container using:
+
+```shell
+# podman build -t grafana-bridge
+```
+
+and then deployed as a pod together with the official grafana container by:
+
+
+
+```shell
+# podman volume create grafana-storage
+# podman pod create --name grafanapod -p 3000:3000
+# podman run --pod grafanapod -e ZSERVER=10.33.23.176 -it localhost/grafana-bridge
+# podman run --pod grafanapod --name=grafana -v grafana-storage:/var/lib/grafana grafana/grafana
+```
+
+Point the ZSERVER to your zimon-collector host (which by default is only open from localhost, so you might need to change the queryinterface in /opt/IBM/zimon/ZIMonCollector.cfg).
+
+Then you can log into http://host:3000 as admin/admin to configure your data source, and upload the dashboards. Grafana configuration changes are persisted to the graphana-storage volume (/var/lib/containers/storage/volumes/grafana-storage/).

--- a/podman.md
+++ b/podman.md
@@ -35,3 +35,39 @@ To run a full "POD" with the grafana-bridge and grafana, with persistent storage
 
 
 Then you can log into http://host:3000 as admin/admin to configure your data source (http://10.33.23.176:4242/), and upload the dashboards. Grafana configuration changes are persisted to the graphana-storage volume (/var/lib/containers/storage/volumes/grafana-storage/).
+
+
+# Systemd service
+
+The grafana-bridge container can be run as a systemd service by first starting it with:
+
+
+```shell
+# podman run -d --net host --name grafana-bridge -it janfrode/grafana-bridge:latest
+```
+
+Then kill it:
+
+```shell
+# podman kill grafana-bridge
+```
+
+Create the service unit file, enable and start it:
+
+```shell
+# cat <<'EOF' > /etc/systemd/system/grafana-bridge.service
+[Unit]
+Description=Grafana Bridge container
+[Service]
+Restart=always
+ExecStart=/usr/bin/podman start -a grafana-bridge
+ExecStop=/usr/bin/podman stop -t 2 grafana-bridge
+
+[Install]
+WantedBy=local.target
+EOF
+
+# systemctl enable grafana-bridge.service
+# systemctl start grafana-bridge.service
+```
+

--- a/podman.md
+++ b/podman.md
@@ -4,17 +4,34 @@ The ***IBM Spectrum Scale bridge for Grafana*** can be built as a podman contain
 # podman build -t grafana-bridge .
 ```
 
-and then deployed as a pod together with the official grafana container by:
+I've pushed x86_64 and ppc64le images to the dockerhub. The "lastest" tag is for x86_64, and "ppc64le" for, eh.. ppc64le. To launch the container on the same node as is running the ZimonCollector, I would suggest using "host" networking. Then it will have access to the ZimonCollector which is by default only listening on 127.0.0.1:
 
+```shell
+# podman run --net host -it janfrode/grafana-bridge:latest
+```
+
+Or on POWER (f.ex. on the ESS EMS):
+
+```shell
+# podman run --net host -it janfrode/grafana-bridge:ppc64le
+```
+
+If running somewhere else than on the ZimonCollector host, you need to tell it the IP-address to connect to using SERVER environment setting, and also expose the bridge ports:
+
+```shell
+# podman run -e SERVER=10.33.23.176 -p 4242:4242 -it janfrode/grafana-bridge
+```
+
+
+To run a full "POD" with the grafana-bridge and grafana, with persistent storage for grafana:
 
 
 ```shell
 # podman volume create grafana-storage
 # podman pod create --name grafanapod -p 3000:3000
-# podman run --pod grafanapod -e ZSERVER=10.33.23.176 -it localhost/grafana-bridge
+# podman run --pod grafanapod -e SERVER=10.33.23.176 -it localhost/grafana-bridge
 # podman run --pod grafanapod --name=grafana -v grafana-storage:/var/lib/grafana grafana/grafana
 ```
 
-Point the ZSERVER to your zimon-collector host (which by default is only open from localhost, so you might need to change the queryinterface in /opt/IBM/zimon/ZIMonCollector.cfg). By running both containers in the same *pod*, they will be able to communicate over localhost. Therefore no ports needs to be exposed on the grafana-bridge, only the grafana web-port is exposed.
 
-Then you can log into http://host:3000 as admin/admin to configure your data source (http://localhost:4242/), and upload the dashboards. Grafana configuration changes are persisted to the graphana-storage volume (/var/lib/containers/storage/volumes/grafana-storage/).
+Then you can log into http://host:3000 as admin/admin to configure your data source (http://10.33.23.176:4242/), and upload the dashboards. Grafana configuration changes are persisted to the graphana-storage volume (/var/lib/containers/storage/volumes/grafana-storage/).

--- a/podman.md
+++ b/podman.md
@@ -1,7 +1,7 @@
 The ***IBM Spectrum Scale bridge for Grafana*** can be built as a podman container using:
 
 ```shell
-# podman build -t grafana-bridge
+# podman build -t grafana-bridge .
 ```
 
 and then deployed as a pod together with the official grafana container by:
@@ -15,6 +15,6 @@ and then deployed as a pod together with the official grafana container by:
 # podman run --pod grafanapod --name=grafana -v grafana-storage:/var/lib/grafana grafana/grafana
 ```
 
-Point the ZSERVER to your zimon-collector host (which by default is only open from localhost, so you might need to change the queryinterface in /opt/IBM/zimon/ZIMonCollector.cfg).
+Point the ZSERVER to your zimon-collector host (which by default is only open from localhost, so you might need to change the queryinterface in /opt/IBM/zimon/ZIMonCollector.cfg). By running both containers in the same *pod*, they will be able to communicate over localhost. Therefore no ports needs to be exposed on the grafana-bridge, only the grafana web-port is exposed.
 
-Then you can log into http://host:3000 as admin/admin to configure your data source, and upload the dashboards. Grafana configuration changes are persisted to the graphana-storage volume (/var/lib/containers/storage/volumes/grafana-storage/).
+Then you can log into http://host:3000 as admin/admin to configure your data source (http://localhost:4242/), and upload the dashboards. Grafana configuration changes are persisted to the graphana-storage volume (/var/lib/containers/storage/volumes/grafana-storage/).


### PR DESCRIPTION
Build grafana-bridge as a podman container. Also give example for how to deploy the bridge and grafana docker container together in a podman pod, so that they can easily communicate over localhost. This could be a good way of deploying grafana + grafana-bridge on the ESS EMS node.