### PR TITLE
publish V7.0.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: bug
 assignees: Helene
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: Helene
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,14 @@ RUN echo "Installed python packages: $(/usr/bin/pip3 list)"
 USER root
 
 RUN mkdir -p /opt/IBM/bridge
-COPY ./source/ /opt/IBM/bridge
-COPY LICENSE /opt/IBM/bridge
-
-RUN mkdir -p /var/mmfs/gen
 RUN mkdir -p /opt/IBM/zimon
+RUN mkdir -p /var/mmfs/gen
+RUN mkdir -p /etc/ssl/certs
+RUN mkdir -p /etc/perfmon-api-keys
+
+COPY LICENSE /licenses/
+
+COPY ./source/ /opt/IBM/bridge
 COPY ./source/gpfsConfig/mmsdrfs* /var/mmfs/gen/
 COPY ./source/gpfsConfig/ZIMon* /opt/IBM/zimon/
 
@@ -33,8 +36,9 @@ ARG PERFMONPORT=9980
 ENV SERVERPORT=$PERFMONPORT
 RUN echo "the PERFMONPORT port is set to $SERVERPORT" 
 
-ARG CERTPATH=None
+ARG CERTPATH='/etc/bridge_ssl/certs'
 ENV TLSKEYPATH=$CERTPATH
+RUN mkdir -p $CERTPATH
 
 ARG KEYFILE=None
 ENV TLSKEYFILE=$KEYFILE
@@ -47,6 +51,7 @@ ENV APIKEYNAME=$KEYNAME
 
 ARG KEYVALUE=None
 ENV APIKEYVALUE=$KEYVALUE
+RUN if [ "${APIKEYVALUE:0:1}" = "/" ]; then ln -s $APIKEYVALUE /etc/perfmon-api-keys; echo "APIKEYVALUE is a PATH"; else echo "APIKEYVALUE not a PATH"; fi
 
 RUN if [ -z "$TLSKEYPATH" ] || [ -z "$TLSCERTFILE" ] || [ -z "$TLSKEYFILE" ] && [ "$PROTOCOL" = "https" ]; then echo "TLSKEYPATH FOR SSL CONNECTION NOT SET - ERROR"; exit 1; else echo "PASS"; fi
 RUN echo "the ssl certificates path is set to $TLSKEYPATH" 
@@ -55,23 +60,38 @@ ARG PMCOLLECTORIP=0.0.0.0
 ENV SERVER=$PMCOLLECTORIP
 RUN echo "the pmcollector server ip is set to $SERVER"
 
+ARG DEFAULTLOGPATH='/var/log/ibm_bridge_for_grafana'
+ENV LOGPATH=$DEFAULTLOGPATH
+RUN mkdir -p $LOGPATH
+RUN echo "the log will use $LOGPATH"
 
 WORKDIR /opt/IBM/bridge
-
-ARG DEFAULTLOGPATH='/var/log/ibm_bridge_for_grafana/install.log'
-ENV LOGPATH=$DEFAULTLOGPATH
-RUN mkdir -p $(dirname $LOGPATH)
-RUN echo "the log will use $(dirname $LOGPATH)"
 RUN echo "$(pwd)"
 
-RUN touch $LOGPATH
-RUN echo "log path: $(dirname $LOGPATH)" >> $LOGPATH
-RUN echo "pmcollector_server: $SERVER" >> $LOGPATH
-RUN echo "ssl certificates location: $TLSKEYPATH" >> $LOGPATH
-RUN echo "HTTP/S port: $PORT" >> $LOGPATH
+RUN touch "${LOGPATH}/install.log"
+RUN echo "log path: $LOGPATH" >> ${LOGPATH}/install.log
+RUN echo "pmcollector_server: $SERVER" >> ${LOGPATH}/install.log
+RUN echo "ssl certificates location: $TLSKEYPATH" >> ${LOGPATH}/install.log
+RUN echo "HTTP/S port: $PORT" >> ${LOGPATH}/install.log
+
+# Create a user 'bridge' under 'root' group
+RUN groupadd -g 2099 bridge
+RUN useradd -rm -d /home/2001 -s /bin/bash -g 2099 -u 2001 bridge
+
+# Chown all the files to the grafanabridge 'bridge' user.
+RUN chown -R 2001:2099 /opt/IBM/bridge
+RUN chown -R 2001:2099 /opt/IBM/zimon
+RUN chown -R 2001:2099 /var/mmfs/gen
+RUN chown -R 2001:2099 /etc/ssl/certs
+RUN chown -R 2001:2099 /etc/perfmon-api-keys
+RUN chown -R 2001:2099 $TLSKEYPATH
+RUN chown -R 2001:2099 $LOGPATH
+
+# Switch to user 'bridge'
+USER 2001
 
 
-CMD ["sh", "-c", "python3 zimonGrafanaIntf.py -c 10 -s $SERVER -r $PROTOCOL -p $PORT -P $SERVERPORT -t $TLSKEYPATH --tlsKeyFile $TLSKEYFILE --tlsCertFile $TLSCERTFILE --apiKeyName $APIKEYNAME --apiKeyValue $APIKEYVALUE"]
+CMD ["sh", "-c", "python3 zimonGrafanaIntf.py -c 10 -s $SERVER -r $PROTOCOL -p $PORT -P $SERVERPORT -t $TLSKEYPATH -l $LOGPATH --tlsKeyFile $TLSKEYFILE --tlsCertFile $TLSCERTFILE --apiKeyName $APIKEYNAME --apiKeyValue $APIKEYVALUE"]
 
 EXPOSE 4242 8443
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 ARG BASE=registry.access.redhat.com/ubi8/ubi:8.5
 FROM $BASE
 
+LABEL com.ibm.name="IBM Spectrum Scale bridge for Grafana"
+LABEL com.ibm.vendor="IBM" 
+LABEL com.ibm.description="This tool translates the IBM Spectrum Scale performance data collected internally \
+to the query requests acceptable by the Grafana integrated openTSDB plugin"
+LABEL com.ibm.summary="It allows the IBM Spectrum Scale users to perform performance monitoring for IBM Spectrum Scale devices using Grafana"
+
 COPY ./requirements/requirements_ubi8.txt  /root/requirements_ubi8.txt
 
 RUN yum install -y python36 python36-devel
@@ -65,20 +71,15 @@ ENV LOGPATH=$DEFAULTLOGPATH
 RUN mkdir -p $LOGPATH
 RUN echo "the log will use $LOGPATH"
 
+# Switch to the working directory
 WORKDIR /opt/IBM/bridge
 RUN echo "$(pwd)"
-
-RUN touch "${LOGPATH}/install.log"
-RUN echo "log path: $LOGPATH" >> ${LOGPATH}/install.log
-RUN echo "pmcollector_server: $SERVER" >> ${LOGPATH}/install.log
-RUN echo "ssl certificates location: $TLSKEYPATH" >> ${LOGPATH}/install.log
-RUN echo "HTTP/S port: $PORT" >> ${LOGPATH}/install.log
 
 # Create a user 'bridge' under 'root' group
 RUN groupadd -g 2099 bridge
 RUN useradd -rm -d /home/2001 -s /bin/bash -g 2099 -u 2001 bridge
 
-# Chown all the files to the grafanabridge 'bridge' user.
+# Chown all the files to the grafanabridge 'bridge' user
 RUN chown -R 2001:2099 /opt/IBM/bridge
 RUN chown -R 2001:2099 /opt/IBM/zimon
 RUN chown -R 2001:2099 /var/mmfs/gen

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Version 7.0.5 (02/10/2022)
-Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi:8.5
-Added 'caCertPath' to the configurable parameters, which allows the user to enable or disable CA certificate verification for the REST API HTTPS connections to the pmcollector.
+Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi:8.5 \
+Added 'caCertPath' to the configurable parameters, which allows the user to enable or disable CA certificate verification for the REST API HTTPS connections to the pmcollector. \
 Added 'retryDelay' to the configurable parameters. Using this parameter the user can control how long the bridge should sleep before re-attempting to query the MetaData, in case no data was returned by pmcollector through the initial bridge startup
 
 Tested with Grafana version 7.5.1 and 8.0.3
@@ -9,7 +9,7 @@ Tested with RedHat community-powered Grafana operator v.4.1
 
 
 # Version 7.0.4 (09/22/2021)
-Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi:8.4-209
+Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi:8.4-209 \
 Moved out the documentation files from the repository content. They have been placed on the [project Wiki](https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/wiki).
 
 Tested with Grafana version 7.5.1 and 8.0.3
@@ -18,7 +18,7 @@ Tested with RedHat community-powered Grafana operator v.3.10.3
 
 
 # Version 7.0.3 (08/13/2021)
-Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi:8.4-206
+Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi:8.4-206 \
 Added requirements_ubi8.txt file including the python versions packages needed to be installed to run the bridge in an OpenShift production environment, on top of the redhat UBI8 image
 
 Tested with Grafana version 7.5.1 and 8.0.3
@@ -27,7 +27,7 @@ Tested with RedHat community-powered Grafana operator v.3.10.3
 
 
 # Version 7.0.2 (08/02/2021)
-Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi
+Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi \
 Changed the sleep time = 60 seconds for re-attempting to get the MetaData from the pmcollector in case no data have been returned during the bridge start instead of stopping the process directly
 
 Tested with Grafana version 7.5.1 and 8.0.3

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+# Version 7.0.6 (04/12/2022)
+Fetch raw data for GPFSDiskCap metrics as workaround for the zimon issue not returning all capacity metrics results. \
+Added non root user to the Dockerfile. This way the main process will be started with a non-root user when running in a container.  \
+Added labels to the Dockerfile
+
+Tested with Grafana version 8.0.3
+Tested with RedHat community-powered Grafana operator v.4.1
+
+
+
 # Version 7.0.5 (02/10/2022)
 Changed the Dockerfile parent image to the registry.access.redhat.com/ubi8/ubi:8.5 \
 Added 'caCertPath' to the configurable parameters, which allows the user to enable or disable CA certificate verification for the REST API HTTPS connections to the pmcollector. \

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,5 +1,16 @@
 The following matrix gives a quick overview of the supported software for the IBM Spectrum Scale bridge for Grafana packages by version number:
 
+# Version 7.0.6 (04/12/2022)
+Classic Scale:
+ - Python 3.6
+ - CherryPy 18.6.1
+ - IBM Spectrum Scale system must run 5.1.3.1 and above
+ - Grafana 8.0.0 and above
+ 
+ Cloud native:
+ - IBM Spectrum Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.1.3.1
+ - RedHat community-powered Grafana-Operator v4.1
+
 # Version 7.0.5 (02/10/2022)
 Classic Scale:
  - Python 3.6

--- a/source/queryHandler/PerfmonRESTclient.py
+++ b/source/queryHandler/PerfmonRESTclient.py
@@ -88,14 +88,12 @@ class perfHTTPrequestHelper(object):
                 res = requests.Response()
                 res.status_code = 503
                 res.reason = "Connection refused from server"
-                res.content = None
                 return res
             except requests.exceptions.RequestException as e:
                 self.logger.debug('doRequest __ RequestException. Request data: {}, Response data: {}'.format(e.request, e.response))
                 res = requests.Response()
                 res.status_code = 404
                 res.reason = "The request could not be processed from server"
-                res.content = None
                 return res
         else:
             raise TypeError('doRequest __ Error: request data wrong format')

--- a/source/queryHandler/Query.py
+++ b/source/queryHandler/Query.py
@@ -182,7 +182,14 @@ class Query(object):
         return self
 
     def __str__(self):
-        dd = '-a' if self.includeDiskData else ''
+        # dd = '-a' if self.includeDiskData else ''
+        # Workaround for RTC Defect 280368: Zimon capacity query does not return all results (seen on CNSA)
+        if (self.metrics and any('gpfs_disk_' in metric for metric in self.metrics)) or (self.sensor and self.sensor == "GPFSDiskCap"):
+            dd = '-ar'
+        elif self.includeDiskData:
+            dd = '-a'
+        else:
+            dd = ''
 
         if self.sensor is not None:
             queryString = 'get -j {0} group {1} bucket_size {2} {3}'.format(


### PR DESCRIPTION
The main changes of 7.0.6:
Fetch raw data for GPFSDiskCap metrics as workaround for the zimon issue not returning all capacity metrics results. 
Added non root user to the Dockerfile. This way the main process will be started with a non-root user when running in a container.  
Added labels to the Dockerfile

Tested with Grafana version 8.0.3
Tested with RedHat community-powered Grafana operator v.4.2