### PR TITLE
Add ENV PYTHONDONTWRITEBYTECODE to prevent writing bytecode to container storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,8 @@ RUN chown -R $UID:$GID $LOGPATH
 # Switch user
 USER $GID
 
+# Do not write byte code inside ephemeral container storage.
+ENV PYTHONDONTWRITEBYTECODE 1
 
 CMD ["sh", "-c", "python3 zimonGrafanaIntf.py -c 10 -s $SERVER -r $PROTOCOL -p $PORT -P $SERVERPORT -t $TLSKEYPATH -l $LOGPATH --tlsKeyFile $TLSKEYFILE --tlsCertFile $TLSCERTFILE --apiKeyName $APIKEYNAME --apiKeyValue $APIKEYVALUE"]
 


### PR DESCRIPTION
Add ENV PYTHONDONTWRITEBYTECODE to prevent writing bytecode to container storage.  Otherwise, python will write byte code inside the container at runtime.  The bytecode helps subsequent startup times, but generally we don't expect either a readonly container root or for writes to be ephemeral.