### PR TITLE
set PYTHONUNBUFFERED

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ LABEL com.ibm.description="This tool translates the IBM Spectrum Scale performan
 to the query requests acceptable by the Grafana integrated openTSDB plugin"
 LABEL com.ibm.summary="It allows the IBM Spectrum Scale users to perform performance monitoring for IBM Spectrum Scale devices using Grafana"
 
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 COPY ./requirements/requirements_ubi8.txt  /root/requirements_ubi8.txt
 
 RUN yum install -y python36 python36-devel

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,8 +125,6 @@ RUN chown -R $UID:$GID $LOGPATH
 # Switch user
 USER $GID
 
-# Do not write byte code inside ephemeral container storage.
-ENV PYTHONDONTWRITEBYTECODE 1
 
 CMD ["sh", "-c", "python3 zimonGrafanaIntf.py -c 10 -s $SERVER -r $PROTOCOL -p $PORT -P $SERVERPORT -t $TLSKEYPATH -l $LOGPATH --tlsKeyFile $TLSKEYFILE --tlsCertFile $TLSCERTFILE --apiKeyName $APIKEYNAME --apiKeyValue $APIKEYVALUE"]
 


### PR DESCRIPTION
Setting PYTHONUNBUFFERED to a non-empty value different from 0 ensures that the python output i.e. the stdout and stderr streams are sent straight to terminal (e.g. your container log) without being first buffered and that you can see the output of your application (e.g. django logs) in real time.

This also ensures that no partial output is held in a buffer somewhere and never written in case the python application crashes.

Since this has been mentioned in several comments and supplementary answers, note that PYTHONUNBUFFERED has absolutely no influence on the input (i.e. the stdin stream).