### PR TITLE
Workaround for capacity metrics

### DIFF
--- a/source/queryHandler/Query.py
+++ b/source/queryHandler/Query.py
@@ -49,6 +49,10 @@ class Query(object):
                   "operation", "protocol", "waiters_time_threshold", "export",
                   "nodegroup", "account", "filesystem", "tct_csap", "tct_operation", "cloud_nodeclass"])
 
+    DISK_CAP_METRICS = set(["gpfs_disk_disksize", "gpfs_disk_free_fullkb", "gpfs_disk_free_fragkb",
+                            "gpfs_pool_disksize", "gpfs_pool_free_fragkb", "gpfs_pool_free_fullkb", 
+                            "gpfs_fs_inode_used", "gpfs_fs_inode_free", "gpfs_fs_inode_alloc", "gpfs_fs_inode_max"])
+
     def __init__(self, metrics=None, bucketsize=1, filters=None, groupby=None, includeDiskData=False):
         '''
         Constructor, filters and groupby must be preformmated
@@ -184,7 +188,11 @@ class Query(object):
     def __str__(self):
         # dd = '-a' if self.includeDiskData else ''
         # Workaround for RTC Defect 280368: Zimon capacity query does not return all results (seen on CNSA)
-        if (self.metrics and any('gpfs_disk_' in metric for metric in self.metrics)) or (self.sensor and self.sensor == "GPFSDiskCap"):
+        if (self.metrics and 
+            any(str(metric) in self.DISK_CAP_METRICS for metric in self.metrics)
+            ) or (self.sensor and 
+                  self.sensor in ("GPFSDiskCap","GPFSPoolCap", "GPFSInodeCap")
+                  ):
             dd = '-ar'
         elif self.includeDiskData:
             dd = '-a'

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -36,4 +36,3 @@ def test_case03():
     query = Query(includeDiskData=True)
     query.sensor = 'GPFSDiskCap'
     assert "-ar" in str(query)
-    

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,21 @@
+from source.queryHandler.Query import Query
+from source.__version__ import __version__ as version
+from nose2.tools.decorators import with_setup
+
+
+def my_setup():
+    global metrics, metrics1
+    metrics = ['cpu_user']
+    metrics1 = ['gpfs_fs_inode_used']
+
+@with_setup(my_setup)
+def test_case01():
+    query = Query(metrics)
+    assert len(str(query)) > 0
+    assert "cpu_user" in str(query)
+    assert "-ar" not in str(query)
+
+@with_setup(my_setup)
+def test_case02():
+    query = Query(metrics1)
+    assert "-ar" in str(query)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,9 +4,10 @@ from nose2.tools.decorators import with_setup
 
 
 def my_setup():
-    global metrics, metrics1
+    global metrics, metrics1, capSensors
     metrics = ['cpu_user']
     metrics1 = ['gpfs_fs_inode_used']
+    capSensors = ['GPFSDiskCap','GPFSPoolCap', 'GPFSInodeCap']
 
 @with_setup(my_setup)
 def test_case01():
@@ -19,3 +20,20 @@ def test_case01():
 def test_case02():
     query = Query(metrics1)
     assert "-ar" in str(query)
+    query.addMetric('cpu_user')
+    assert "-ar" in str(query)
+
+@with_setup(my_setup)
+def test_case03():
+    for sensor in capSensors:
+        query = Query()
+        query.sensor = sensor
+        assert "-ar" in str(query)
+    query = Query()
+    query.sensor = 'CPU'
+    assert "-ar" not in str(query)
+    assert "group" in str(query)
+    query = Query(includeDiskData=True)
+    query.sensor = 'GPFSDiskCap'
+    assert "-ar" in str(query)
+    


### PR DESCRIPTION
- added the "-ar" to the zimon query string for all capacity sensors metrics requests
- added query unit tests