### PR TITLE
Add W503 to ignored flake8 rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Test
           command: |
             . venv/bin/activate
-            flake8 --max-line-length=999 --ignore=E731,E741,E712,E722 --exclude=venv* --statistics
+            flake8 --max-line-length=999 --ignore=E731,E741,E712,E722,W503 --exclude=venv* --statistics
             nose2
       - setup_remote_docker:
           version: 19.03.13


### PR DESCRIPTION
W504 and W503 conflict with each other (and are both disabled by default) -- by setting ignore you've re-enabled them. extend-ignore does not have this problem as it augments the default set of ignored codes

Signed-off-by: hwassman <hwassman@de.ibm.com>