### PR TITLE
update Docker version in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             flake8 --max-line-length=999 --ignore=E731,E741,E712,E722,W503 --exclude=venv* --statistics
             nose2
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.17
       - run:
           name: Build Docker image
           command: |


### PR DESCRIPTION
Use Docker version 20.10.17 for remote Docker jobs (circle CI/CD tasks) 

For more info check [Setup_remote_docker Architecture Change](https://discuss.circleci.com/t/setup-remote-docker-architecture-change/45303?mkt_tok=NDg1LVpNSC02MjYAAAGHPYyq6Dk4GQTK6Ou9VNFLunblcJ6fVom9_bIhGpC67_iWnEDkljBe7M028L66-ph8O_x_IprYBN9TaDMvwiZvk55xcQcDQKubt4kzk2PmM6ht-Q)


Signed-off-by: hwassman <hwassman@de.ibm.com>