### PR TITLE
fix ImportError in system pip wrappers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,8 @@ RUN echo "the log will use $LOGPATH"
 COPY ./requirements/requirements_ubi8.txt  /root/requirements_ubi8.txt
 
 RUN yum install -y python36 python36-devel && \
-    /usr/bin/pip3 install --upgrade pip && \
-    /usr/bin/pip3 install -r /root/requirements_ubi8.txt && \
+    /usr/bin/python3 -m pip install --upgrade pip && \
+    /usr/bin/python3 -m pip install -r /root/requirements_ubi8.txt && \
     echo "Installed python version: $(/usr/bin/python3 -V)" && \
     echo "Installed python packages: $(/usr/bin/pip3 list)"
 


### PR DESCRIPTION
Resolves the following issue in CI/CD process:

Installing collected packages: pip
Successfully installed pip-21.3.1
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.