### PR TITLE
Add compile python packages command to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,10 @@ RUN echo "the log will use $LOGPATH"
 COPY ./requirements/requirements_ubi9.txt  /root/requirements_ubi9.txt
 
 RUN yum install -y python39 python3-pip && \
-    /usr/bin/python3 -m pip install --upgrade pip && \
-    /usr/bin/python3 -m pip install -r /root/requirements_ubi9.txt && \
+    /usr/bin/python3 -m pip install --user --upgrade pip && \
+    /usr/bin/python3 -m pip install --user -r /root/requirements_ubi9.txt && \
     echo "Installed python version: $(/usr/bin/python3 -V)" && \
-    echo "Installed python packages: $(/usr/bin/pip3 list)"
+    echo "Installed python packages: $(/usr/bin/python3 -m pip list)"
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,16 @@ ENV LOGPATH=$DEFAULTLOGPATH
 RUN echo "the log will use $LOGPATH"
 
 COPY ./requirements/requirements_ubi9.txt  /root/requirements_ubi9.txt
+# COPY ./requirements/requirements_ubi.in  /root/requirements_ubi.in
 
 RUN yum install -y python39 python3-pip && \
-    /usr/bin/python3 -m pip install --user --upgrade pip && \
-    /usr/bin/python3 -m pip install --user -r /root/requirements_ubi9.txt && \
+    /usr/bin/python3 -m pip install --user --upgrade pip 
+
+# RUN /usr/bin/python3 -m pip install --user pip-tools && \
+#     /usr/bin/python3 -m piptools compile /root/requirements_ubi.in  --output-file /root/requirements_ubi9.txt && \
+#     echo "Compiled python packages: $(cat /root/requirements_ubi9.txt)"
+
+RUN /usr/bin/python3 -m pip install --user -r /root/requirements_ubi9.txt && \
     echo "Installed python version: $(/usr/bin/python3 -V)" && \
     echo "Installed python packages: $(/usr/bin/python3 -m pip list)"
 


### PR DESCRIPTION
In case you need run the grafana-bridge on a different base image than default, it might happen that the installed python module controlled through requirements.txt are outdated or not compatible with your base image. You can let podman to recompile the requirements file during image build by commenting out the following lines in the Dockerfile
```
# COPY ./requirements/requirements_ubi.in  /root/requirements_ubi.in

# RUN /usr/bin/python3 -m pip install --user pip-tools && \
#     /usr/bin/python3 -m piptools compile /root/requirements_ubi.in  --output-file /root/requirements_ubi9.txt && \
#     echo "Compiled python packages: $(cat /root/requirements_ubi9.txt)"
``` 