### PR TITLE
Remove packages included in ubi9/python39 from requirements_ubi.in

### DIFF
--- a/requirements/requirements_ubi.in
+++ b/requirements/requirements_ubi.in
@@ -1,12 +1,12 @@
-# This file is used for generating python requirements list "requirements_ubi8.txt".
+# This file is used for generating python requirements list "requirements_ubi9.txt".
 # It includes the packages needed to be installed to run the IBM Spectrum Scale Performance Monitoring bridge for Grafana
 # in an OpenShift production environment, on top of the redhat UBI8 image.
 #
 # To update, run:
 #
-#  $ pip-compile requirements_ubi8.in  --output-file requirements_ubi8.txt
+#  $ pip-compile requirements_ubi.in  --output-file requirements_ubi9.txt
 #
-setuptools
+# setuptools
 cherrypy
-urllib3
-requests
+# urllib3
+# requests


### PR DESCRIPTION
requirements_ubi.in manages python packages which need to be installed on top of the Python package installation.
requests, urllib3 and setuptools are allready included in ubi9/python39
https://catalog.redhat.com/software/containers/ubi9/python-39/61a61032bfd4a5234d59629e?container-tabs=packages