### PR TITLE
Add parsing for multiple pmsensors config files

### DIFF
--- a/source/queryHandler/SensorConfig.py
+++ b/source/queryHandler/SensorConfig.py
@@ -108,7 +108,6 @@ def parseSensorsConfig(sensorsConfig, logger):
         else:
             end = None
             sensorsStr = sensorsConfig[sensorsConfig.find("sensors"):end]
-            logger.info(sensorsStr)
         sensorsList = re.findall('(?P<sensor>{.*?})(?:,|$)', sensorsStr)
         for sensorString in sensorsList:
             sensorAttr = re.findall(r'(?P<name>\w+) = (?P<value>\"\S*\"|\d+)', sensorString)

--- a/source/queryHandler/SensorConfig.py
+++ b/source/queryHandler/SensorConfig.py
@@ -29,7 +29,7 @@ except Exception:
     pass
 
 mmsdrfsFile = '/var/mmfs/gen/mmsdrfs'
-zimonFile = '/opt/IBM/zimon/ZIMonSensors.cfg'
+zimonFile = '/opt/IBM/zimon'
 collectorsFile = '/opt/IBM/zimon/ZIMonCollector.cfg'
 
 
@@ -57,28 +57,44 @@ def readSensorsConfigFromMMSDRFS(logger=None):
     return parseSensorsConfig(data, logger)
 
 
-def readSensorsConfig(logger=None):
+def readSensorsConfig(logger=None, customFile=None):
     '''
     :return: list of dictionaries with sensorsName as key and the values of the sensors in the ZimonSensors.cfg
     '''
     if not logger:
         logger = SysmonLogger.getLogger(__name__)
 
-    if not os.path.isfile(zimonFile):
+    global zimonFile
+    if customFile:
+        zimonFile = rf"{customFile}"
+
+    sensorConfigFiles = []
+    parsedSensors = []
+
+    if os.path.isfile(zimonFile):
+        sensorConfigFiles.append(zimonFile)
+    elif os.path.isdir(zimonFile):
+        for root, dirs, files in os.walk(zimonFile):
+            for file in files:
+                if file.endswith(".cfg"):
+                    sensorConfigFiles.append(os.path.join(root, file))
+    else :
         logger.details("ZiMon sensor configuration file not found (%s) ", zimonFile)
         print("ZiMon sensor configuration file not found")
         raise OSError(2, 'No such file or directory', zimonFile)
 
     data = ""
     logger.debug("readSensorsConfig attempt to read %s", zimonFile)
-    try:
-        with open(zimonFile) as myfile:
-            data = myfile.read().replace('\n', '')
-    except (Exception, IOError) as error:
-        logger.details("failed trying read %s with reason: %s", zimonFile, error)
-        return []
-    # parse config file in a list of dictionaries format
-    return parseSensorsConfig(data, logger)
+    for file in sensorConfigFiles:
+        try:
+            with open(file) as myfile:
+                data = myfile.read().replace('\n', '')
+        except (Exception, IOError) as error:
+            logger.details("failed trying read %s with reason: %s", zimonFile, error)
+            continue
+        # parse config file in a list of dictionaries format
+        parsedSensors.extend(parseSensorsConfig(data, logger))
+    return parsedSensors
 
 
 def parseSensorsConfig(sensorsConfig, logger):
@@ -86,7 +102,13 @@ def parseSensorsConfig(sensorsConfig, logger):
     logger.debug("invoke parseSensorsConfig")
     try:
         sensors = []
-        sensorsStr = sensorsConfig[sensorsConfig.find("sensors"):sensorsConfig.find("smbstat")]
+        sensorsStr = ""
+        if sensorsConfig.find("smbstat") != -1:
+            sensorsStr = sensorsConfig[sensorsConfig.find("sensors"):sensorsConfig.find("smbstat")]
+        else:
+            end = None
+            sensorsStr = sensorsConfig[sensorsConfig.find("sensors"):end]
+            logger.info(sensorsStr)
         sensorsList = re.findall('(?P<sensor>{.*?})(?:,|$)', sensorsStr)
         for sensorString in sensorsList:
             sensorAttr = re.findall(r'(?P<name>\w+) = (?P<value>\"\S*\"|\d+)', sensorString)

--- a/tests/test_data/ZIMonSensors-protocols-wrong.cfg
+++ b/tests/test_data/ZIMonSensors-protocols-wrong.cfg
@@ -1,0 +1,24 @@
+colCandidates = "ibm-spectrum-scale-pmcollector-0.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local", "ibm-spectrum-scale-pmcollector-1.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local"
+colRedundancy = 2
+collectors = {
+   host = "ibm-spectrum-scale-pmcollector-0.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local"
+   port = "4739"
+}, {
+   host = "ibm-spectrum-scale-pmcollector-1.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local"
+   port = "4739"
+}
+#config = "/opt/IBM/zimon/ZIMonSensors.cfg"
+daemonize = T
+delay_initial_poll = T
+#hostname = ""
+#ipfixinterface = "0.0.0.0"
+#logfile = "/var/log/zimon/ZIMonSensors.log"
+#logfile = "stdout"
+loglevel = "info"
+piddir = "/var/run"
+release = "5.1.4-0"
+sensors = {
+        name = "NFSIO"
+        period = 10
+        type = "Generic"
+}

--- a/tests/test_data/ZIMonSensors-protocols.cfg
+++ b/tests/test_data/ZIMonSensors-protocols.cfg
@@ -1,0 +1,25 @@
+colCandidates = "ibm-spectrum-scale-pmcollector-0.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local", "ibm-spectrum-scale-pmcollector-1.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local"
+colRedundancy = 2
+collectors = {
+   host = "ibm-spectrum-scale-pmcollector-0.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local"
+   port = "4739"
+}, {
+   host = "ibm-spectrum-scale-pmcollector-1.ibm-spectrum-scale-pmcollector.ibm-spectrum-scale.svc.cluster.local"
+   port = "4739"
+}
+#config = "/opt/IBM/zimon/ZIMonSensors.cfg"
+daemonize = T
+delay_initial_poll = T
+#hostname = ""
+#ipfixinterface = "0.0.0.0"
+#logfile = "/var/log/zimon/ZIMonSensors.log"
+#logfile = "stdout"
+loglevel = "info"
+piddir = "/var/run"
+release = "5.1.4-0"
+sensors = {
+        name = "NFSIO"
+        period = 10
+        type = "Generic"
+}
+smbstat = ""

--- a/tests/test_data/ZIMonSensors.cfg
+++ b/tests/test_data/ZIMonSensors.cfg
@@ -1,0 +1,153 @@
+cephMon = "/opt/IBM/zimon/CephMonProxy"
+cephRados = "/opt/IBM/zimon/CephRadosProxy"
+colCandidates = "c699gpfs01-ib0.c699.net"
+colRedundancy = 1
+collectors = {
+	host = "c699gpfs01-ib0.c699.net"
+	port = "4739"
+}
+config = "/opt/IBM/zimon/ZIMonSensors.cfg"
+ctdbstat = ""
+daemonize = T
+hostname = ""
+ipfixinterface = "0.0.0.0"
+logfile = "/var/log/zimon/ZIMonSensors.log"
+loglevel = "info"
+mmcmd = "/opt/IBM/zimon/MMCmdProxy"
+mmdfcmd = "/opt/IBM/zimon/MMDFProxy"
+mmpmon = "/opt/IBM/zimon/MmpmonSockProxy"
+piddir = "/var/run"
+release = "5.0.0-1"
+sensors = {
+	name = "CPU"
+	period = 1
+},
+{
+	name = "Load"
+	period = 1
+},
+{
+	name = "Memory"
+	period = 1
+},
+{
+	name = "Network"
+	period = 1
+},
+{
+	name = "Netstat"
+	period = 10
+},
+{
+	name = "Diskstat"
+	period = 0
+},
+{
+	name = "DiskFree"
+	period = 600
+},
+{
+	name = "Infiniband"
+	period = 1
+},
+{
+	name = "GPFSDisk"
+	period = 0
+},
+{
+	name = "GPFSFilesystem"
+	period = 0
+},
+{
+	name = "GPFSNSDDisk"
+	period = 0
+	restrict = "nsdNodes"
+},
+{
+	name = "GPFSPoolIO"
+	period = 10
+},
+{
+	name = "GPFSVFS"
+	period = 10
+},
+{
+	name = "GPFSIOC"
+	period = 10
+},
+{
+	name = "GPFSVIO64"
+	period = 0
+},
+{
+	name = "GPFSPDDisk"
+	period = 0
+	restrict = "nsdNodes"
+},
+{
+	name = "GPFSvFLUSH"
+	period = 0
+},
+{
+	name = "GPFSNode"
+	period = 10
+},
+{
+	name = "GPFSNodeAPI"
+	period = 10
+},
+{
+	name = "GPFSFilesystemAPI"
+	period = 0
+},
+{
+	name = "GPFSLROC"
+	period = 0
+},
+{
+	name = "GPFSCHMS"
+	period = 10
+},
+{
+	name = "GPFSAFM"
+	period = 0
+},
+{
+	name = "GPFSAFMFS"
+	period = 0
+},
+{
+	name = "GPFSAFMFSET"
+	period = 0
+},
+{
+	name = "GPFSRPCS"
+	period = 10
+},
+{
+	name = "GPFSWaiters"
+	period = 10
+},
+{
+	name = "GPFSFilesetQuota"
+	period = 0
+},
+{
+	name = "GPFSFileset"
+	period = 0
+	restrict = "c699gpfs01-ib0.c699.net"
+},
+{
+	name = "GPFSPool"
+	period = 0
+	restrict = "c699gpfs01-ib0.c699.net"
+},
+{
+	name = "GPFSDiskCap"
+	period = 0
+},
+{
+	name = "GPFSLWEKafkaProducers"
+	period = 0
+}
+smbstat = ""

--- a/tests/test_zimon_config_parser.py
+++ b/tests/test_zimon_config_parser.py
@@ -1,0 +1,50 @@
+import os
+# import source.queryHandler.SensorConfig as SensorConfig
+from source.queryHandler.SensorConfig import parseSensorsConfig, readSensorsConfig
+from source.bridgeLogger import configureLogging
+from nose2.tools.such import helper as assert_helper
+from nose2.tools.decorators import with_setup
+from argparse import Namespace
+
+
+
+def my_setup():
+    global path, logger, mainSensorsConfig, wrongSensorsConfig, zimonFile, sensorsCount
+    path = os.getcwd()
+    logger = configureLogging(path, None)
+    mainSensorsConfig = 'ZIMonSensors.cfg'
+    wrongSensorsConfig = 'ZIMonSensors-protocols-wrong.cfg'
+    sensorsCount = 0
+
+@with_setup(my_setup)
+def test_case01():
+    with assert_helper.assertRaises(OSError):
+        sensorsList = readSensorsConfig(logger)
+
+@with_setup(my_setup)
+def test_case02():
+    zimonFile = os.path.join(path, "tests", "test_data", mainSensorsConfig)
+    sensorsList = readSensorsConfig(logger, zimonFile)
+    assert isinstance(sensorsList , list)
+    assert len(sensorsList) > 0
+
+@with_setup(my_setup)
+def test_case03():
+    zimonFile = os.path.join(path, "tests", "test_data", wrongSensorsConfig)
+    sensorsList = readSensorsConfig(logger, zimonFile)
+    assert isinstance(sensorsList , list)
+    assert len(sensorsList) > 0
+
+@with_setup(my_setup)
+def test_case04():
+    zimonFile = os.path.join(path, "tests", "test_data", mainSensorsConfig)
+    sensorsList = readSensorsConfig(logger, zimonFile)
+    sensorsCount = len(sensorsList)
+
+    zimonFile = os.path.join(path, "tests", "test_data")
+    print(zimonFile)
+    sensorsList1 = readSensorsConfig(logger, zimonFile)
+    print(len(sensorsList1))
+    assert isinstance(sensorsList1 , list)
+    assert len(sensorsList1) > sensorsCount
+


### PR DESCRIPTION
Required the function parsing multiple ZIMonSensors( .cfg) file

Background: In cloud native environment the NFS-Ganesha service is running in a separate pod. Also the used NFS sensors configuration is managed in a separate cfg file.

Solution: Instead of parsing /opt/IBM/zimon/ZIMonSensors.cfg parse all .cfg files stored in /opt/IBM/zimon