### PR TITLE
ConfigWatchThread need to be properly stoped 

### DIFF
--- a/source/queryHandler/SensorConfig.py
+++ b/source/queryHandler/SensorConfig.py
@@ -32,6 +32,14 @@ mmsdrfsFile = '/var/mmfs/gen/mmsdrfs'
 zimonFile = '/opt/IBM/zimon'
 collectorsFile = '/opt/IBM/zimon/ZIMonCollector.cfg'
 
+def get_config_paths():
+    files_to_watch = []
+    if os.path.isfile(mmsdrfsFile):
+        files_to_watch.append(mmsdrfsFile)
+    else:
+        files_to_watch.append(zimonFile)
+    return files_to_watch
+
 
 def readSensorsConfigFromMMSDRFS(logger=None):
     '''

--- a/source/queryHandler/SensorConfig.py
+++ b/source/queryHandler/SensorConfig.py
@@ -32,6 +32,7 @@ mmsdrfsFile = '/var/mmfs/gen/mmsdrfs'
 zimonFile = '/opt/IBM/zimon'
 collectorsFile = '/opt/IBM/zimon/ZIMonCollector.cfg'
 
+
 def get_config_paths():
     files_to_watch = []
     if os.path.isfile(mmsdrfsFile):

--- a/source/watcher.py
+++ b/source/watcher.py
@@ -20,14 +20,17 @@ Created on Sep 22, 2023
 @author: HWASSMAN
 '''
 
+import cherrypy
 import os
 import time
 from bridgeLogger import getBridgeLogger
 from messages import MSG
+from threading import Thread
 
 
 class ConfigWatcher(object):
     running = False
+    thread = None
     refresh_delay_secs = 30
 
     def __init__(self, watch_paths, call_func_on_change=None, *args, **kwargs):
@@ -39,7 +42,16 @@ class ConfigWatcher(object):
         self.args = args
         self.kwargs = kwargs
 
-    def update_files_list(self):
+    def start_watch(self):
+        """ Function to start watch in a thread"""
+        self.running = True
+        if not self.thread:
+            self.thread = Thread(name='ConfigWatchThread', target=self.watch)
+            self.thread.start()
+            cherrypy.engine.log('Started custom thread %r.' % self.thread.name)
+            self.logger.debug(MSG['StartWatchingFiles'].format(self.paths))
+
+    def _update_files_list(self):
         oldfiles = self.filenames.copy()
         for path in self.paths:
             if os.path.isfile(path):
@@ -54,7 +66,7 @@ class ConfigWatcher(object):
         for file in self.filenames.difference(oldfiles):
             self.logger.debug(MSG['FileAddedToWatch'].format(file))
 
-    def look(self):
+    def _look(self):
         """ Function to check if a file timestamp has changed"""
         for filename in self.filenames:
             stamp = os.stat(filename).st_mtime
@@ -69,14 +81,12 @@ class ConfigWatcher(object):
 
     def watch(self):
         """ Function to keep watching in a loop """
-        self.running = True
-        self.logger.debug(MSG['StartWatchingFiles'].format(self.paths))
         while self.running:
             try:
                 # Look for changes
                 time.sleep(self.refresh_delay_secs)
-                self.update_files_list()
-                self.look()
+                self._update_files_list()
+                self._look()
             except KeyboardInterrupt:
                 self.logger.details(MSG['StopWatchingFiles'].format(self.paths))
                 break
@@ -91,4 +101,11 @@ class ConfigWatcher(object):
 
     def stop_watch(self):
         """ Function to break watching """
-        self.running = False
+        try:
+            self.running = False
+            if self.thread:
+                self.thread.join()
+                cherrypy.engine.log('Stopped custom thread %r.' % self.thread.name)
+                self.thread = None
+        except KeyboardInterrupt:
+           print(f"Recived KeyboardInterrupt during stopping the thread {self.thread.name}")

--- a/source/watcher.py
+++ b/source/watcher.py
@@ -108,4 +108,4 @@ class ConfigWatcher(object):
                 cherrypy.engine.log('Stopped custom thread %r.' % self.thread.name)
                 self.thread = None
         except KeyboardInterrupt:
-           print(f"Recived KeyboardInterrupt during stopping the thread {self.thread.name}")
+            print(f"Recived KeyboardInterrupt during stopping the thread {self.thread.name}")

--- a/tests/test_configWatcher.py
+++ b/tests/test_configWatcher.py
@@ -3,7 +3,6 @@ import time
 from source.watcher import ConfigWatcher
 from source.bridgeLogger import configureLogging
 from nose2.tools.decorators import with_setup
-from threading import Thread
 
 
 def my_setup():

--- a/tests/test_configWatcher.py
+++ b/tests/test_configWatcher.py
@@ -21,11 +21,9 @@ def test_case01():
     cw = ConfigWatcher([dummyFile])
     assert len(cw.paths) == 1
     assert len(cw.filenames) == 0
-    t = Thread(name='ConfigWatchThread', target=cw.watch)
-    t.start()
+    cw.start_watch()
     time.sleep(3)
     cw.stop_watch()
-    t.join()
     assert len(cw.paths) == 1
     assert len(cw.filenames) == 0
 
@@ -35,10 +33,8 @@ def test_case02():
     cw = ConfigWatcher([path])
     assert len(cw.paths) > 0
     assert len(cw.filenames) == 0
-    t = Thread(name='ConfigWatchThread', target=cw.watch)
-    t.start()
+    cw.start_watch()
     time.sleep(3)
     cw.stop_watch()
-    t.join()
     assert len(cw.paths) > 0
     assert len(cw.filenames) > 1


### PR DESCRIPTION
This fix should solve that the cherrypy process hanging because of ConfigWatchThread still running
```
[09/Oct/2023:12:11:24] ENGINE Restarting because /opt/IBM/bridge/zimonGrafanaIntf.py changed.
[09/Oct/2023:12:11:24] ENGINE Stopped thread 'Autoreloader'.
[09/Oct/2023:12:11:24] ENGINE Bus STOPPING
[09/Oct/2023:12:11:24] ENGINE HTTP Server cherrypy._cpwsgi_server.CPWSGIServer(('0.0.0.0', 4242)) shut down
[09/Oct/2023:12:11:24] ENGINE Bus STOPPED
[09/Oct/2023:12:11:24] ENGINE Bus EXITING
[09/Oct/2023:12:11:24] ENGINE Bus EXITED
[09/Oct/2023:12:11:24] ENGINE Waiting for child threads to terminate...
[09/Oct/2023:12:11:24] ENGINE Waiting for thread ConfigWatchThread.

```