### PR TITLE
Allow to query original counters

### DIFF
--- a/source/collector.py
+++ b/source/collector.py
@@ -167,7 +167,7 @@ class SensorTimeSeries(object):
 
 @classattributes(dict(metricsaggr=None, filters=None, grouptags=None,
                       start='', end='', nsamples=0, duration=0,
-                      dsBucketSize=0, dsOp=''),
+                      dsBucketSize=0, dsOp='', rowData=False),
                  ['sensor', 'period'])
 class QueryPolicy(object):
 
@@ -182,6 +182,7 @@ class QueryPolicy(object):
         '''Returns zimon query string '''
         query = Query(includeDiskData=self.md.includeDiskData)
         query.normalize_rates = False
+        query.rowData = self.rowData
 
         if not self.metricsaggr and not self.sensor:
             self.logger.error(MSG['QueryError'].

--- a/source/opentsdb.py
+++ b/source/opentsdb.py
@@ -134,6 +134,8 @@ class OpenTsdbApi(object):
             args['filters'] = filters
             args['grouptags'] = grouptags
 
+        args['rowData'] = q.get('explicitTags', False)
+
         args['sensor'] = sensor
         args['period'] = period
 

--- a/source/queryHandler/Query.py
+++ b/source/queryHandler/Query.py
@@ -91,6 +91,7 @@ class Query(object):
         self.timeRep = ' now'         # string time representation
         self.measurements = {}
         self.normalize_rates = True
+        self.rowData = False
         self.key = None
         self.sensor = None
 
@@ -199,15 +200,20 @@ class Query(object):
         else:
             dd = ''
 
-        if self.sensor is not None:
-            queryString = 'get -j {0} group {1} bucket_size {2} {3}'.format(
-                dd, self.sensor, self.bucket_size, self.timeRep)
-        elif self.key is not None:
-            queryString = 'get -j {0} {1} bucket_size {2} {3}'.format(
-                dd, self.key, self.bucket_size, self.timeRep)
+        if self.rowData:
+            raw = '-z'
         else:
-            queryString = 'get -j {0} metrics {1} bucket_size {2} {3}'.format(
-                dd, ','.join(self.metrics), self.bucket_size, self.timeRep)
+            raw = ''
+
+        if self.sensor is not None:
+            queryString = 'get -j {0} {1} group {2} bucket_size {3} {4}'.format(
+                dd, raw, self.sensor, self.bucket_size, self.timeRep)
+        elif self.key is not None:
+            queryString = 'get -j {0} {1} {2} bucket_size {3} {4}'.format(
+                dd, raw, self.key, self.bucket_size, self.timeRep)
+        else:
+            queryString = 'get -j {0} {1} metrics {2} bucket_size {3} {4}'.format(
+                dd, raw, ','.join(self.metrics), self.bucket_size, self.timeRep)
 
         if self.filters:
             queryString += ' from ' + ",".join(self.filters)


### PR DESCRIPTION
Usually the zimon returns delta values for the metric type=counter.
Added -z option to the Query class to allow query original counter values.