### PR TITLE
Allow to export raw counters data by PrometheusExporter API

### DIFF
--- a/.pydevproject
+++ b/.pydevproject
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?eclipse-pydev version="1.0"?><pydev_project>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python interpreter</pydev_property>
+    
+    <pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+    
+    <pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python interpreter</pydev_property>
+    
+    <pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
+        <path>/${PROJECT_DIR_NAME}</path>
+    </pydev_pathproperty>
 </pydev_project>

--- a/source/config.ini
+++ b/source/config.ini
@@ -14,8 +14,12 @@ protocol = http
 ##################### Prometheus Exporter API Connection Defaults #############
 # Port number the bridge listening on for Prometheus server https requests;
 # ssl cert and key configuration required
-
 # prometheus = 9250
+
+# Sensor counters deltas will be exported by default.
+# Set True if you want export original sensor counters.
+# rawCounters = False
+
 
 #################################### API SSL OAuth ############################
 [tls]

--- a/source/queryHandler/QueryHandler.py
+++ b/source/queryHandler/QueryHandler.py
@@ -495,7 +495,7 @@ class QueryHandler2:
         res = self.__do_RESTCall('perfmon/data', 'GET', params)
 
         if res is None:
-            self.logger.error('QueryHandler: query response has no data results')
+            self.logger.debug('QueryHandler: query response has no data results')
             return None
         try:
             result = json.loads(res, strict=False)
@@ -528,7 +528,7 @@ class QueryHandler2:
                 raise PerfmonConnError("{} {}".format(_response.status_code, _response.reason))
             else:
                 msg = "Perfmon RESTcall error __ Server responded: {} {}".format(_response.status_code, _response.reason)
-                self.logger.warning(msg)
+                self.logger.debug(msg)
                 if _response.content:
                     contentMsg = _response.content.decode('utf-8', "strict")
                     self.logger.details(f'Response content:{contentMsg}')

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -261,7 +261,10 @@ def main(argv):
 
     if args.get('prometheus', None):
         bind_prometheus_server(args)
-        exporter = PrometheusExporter(logger, mdHandler, args.get('prometheus'))
+        exporter = PrometheusExporter(logger,
+                                      mdHandler,
+                                      args.get('prometheus'),
+                                      args.get('rawCounters', False))
         # query to force update of metadata (zimon feature)
         cherrypy.tree.mount(exporter, '/update',
                             {'/':


### PR DESCRIPTION
Usually zimon returns delta values for a metric query. With this PR added an option that allows the user to enable the usage of the original sensor counter values and export them to Prometheus