### PR TITLE
Add sensorsconfig endpoint

### DIFF
--- a/source/opentsdb.py
+++ b/source/opentsdb.py
@@ -294,6 +294,12 @@ class OpenTsdbApi(object):
             resp = self.md.update()
             # resp = json.dumps(resp)
 
+        # /sensorsconfig
+        elif '/sensorsconfig' == cherrypy.request.script_name:
+            # cherrypy.response.headers['Content-Type'] = 'application/json'
+            resp = self.md.SensorsConfig
+            # resp = json.dumps(resp)
+
         elif 'aggregators' in cherrypy.request.script_name:
             resp = ["noop", "sum", "avg", "max", "min", "rate"]
 

--- a/source/prometheus.py
+++ b/source/prometheus.py
@@ -153,6 +153,11 @@ class PrometheusExporter(object):
             # cherrypy.response.headers['Content-Type'] = 'application/json'
             resp = self.md.update()
 
+        # /sensorsconfig
+        elif '/sensorsconfig' == cherrypy.request.script_name:
+            # cherrypy.response.headers['Content-Type'] = 'application/json'
+            resp = self.md.SensorsConfig
+
         elif self.endpoints and self.endpoints.get(cherrypy.request.script_name,
                                                    None):
             sensor = self.endpoints[cherrypy.request.script_name]

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -258,6 +258,12 @@ def main(argv):
                              {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
                              }
                             )
+        # query for list configured zimon sensors
+        cherrypy.tree.mount(api, '/sensorsconfig',
+                            {'/':
+                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                             }
+                            )
         # query for list of aggregators (openTSDB)
         cherrypy.tree.mount(api, '/api/aggregators',
                             {'/':
@@ -283,6 +289,12 @@ def main(argv):
 
         # query to force update of metadata (zimon feature)
         cherrypy.tree.mount(exporter, '/update',
+                            {'/':
+                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                             }
+                            )
+        # query for list configured zimon sensors
+        cherrypy.tree.mount(api, '/sensorsconfig',
                             {'/':
                              {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
                              }


### PR DESCRIPTION
The endpoint  /sensorsconfig will be used to print out zimon sensors configuration.
Example.
![grafik](https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/assets/22845495/d6de5088-3395-4b48-bf72-c28f1f565446)
