### PR TITLE
Update Dockerfile for supporting Prometheus Exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,13 @@ ARG HTTPPROTOCOL=http
 ENV PROTOCOL=$HTTPPROTOCOL
 RUN echo "the HTTP/S protocol is set to $PROTOCOL"
 
-ARG HTTPPORT=4242
+ARG HTTPPORT=None
 ENV PORT=$HTTPPORT
-RUN echo "the HTTP/S port is set to $PORT" 
+RUN echo "the OpentTSDB API HTTP/S port is set to $PORT"
+
+ARG PROMPORT=None
+ENV PROMETHEUS=$PROMPORT
+RUN echo "the Prometheus API HTTPS port is set to $PROMETHEUS" 
 
 ARG PERFMONPORT=9980
 ENV SERVERPORT=$PERFMONPORT
@@ -125,8 +129,8 @@ RUN chown -R $UID:$GID /opt/IBM/bridge && \
 # Switch user
 USER $GID
 
-CMD ["sh", "-c", "python3 zimonGrafanaIntf.py -c 10 -s $SERVER -r $PROTOCOL -p $PORT -P $SERVERPORT -t $TLSKEYPATH -l $LOGPATH --tlsKeyFile $TLSKEYFILE --tlsCertFile $TLSCERTFILE --apiKeyName $APIKEYNAME --apiKeyValue $APIKEYVALUE"]
+CMD ["sh", "-c", "python3 zimonGrafanaIntf.py -c 10 -s $SERVER -r $PROTOCOL -p $PORT -e $PROMETHEUS -P $SERVERPORT -t $TLSKEYPATH -l $LOGPATH --tlsKeyFile $TLSKEYFILE --tlsCertFile $TLSCERTFILE --apiKeyName $APIKEYNAME --apiKeyValue $APIKEYVALUE"]
 
-EXPOSE 4242 8443
+EXPOSE 4242 8443 9250
 
 #CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
As grafana-bridge will support multiple plugin APIs in the future, all application ports will be disabled by default.
However, this should not prevent the user from building the container image and exposing ports for specific plugins during pod deployment.

Create the image
```
# podman build -t bridge_image:latest .
```

Run a grafana-bridge pod for OpenTSDB plugin
```
# podman run -dt -p 8443:8443 -e "SERVER=9.152.187.158" -e "APIKEYVALUE=dc8c2900-e642-488d-b5a8-a67bf70a9389" -e "PORT=8443" -e "PROTOCOL=https" -e "TLSKEYPATH=/etc/bridge_ssl/certs" -e "TLSKEYFILE=privkey.pem" -e "TLSCERTFILE=cert.pem" -v /tmp:/var/log/ibm_bridge_for_grafana -v /etc/bridge_ssl/certs:/etc/bridge_ssl/certs --pod new:my-bridge-pod --name grafana_bridge bridge_image:latest
```
Run a grafana-bridge pod for OpenTSDB and Prometheus plugin
```
# podman run -dt -p 8443:8443,9250:9250 -e "SERVER=9.152.187.158" -e "APIKEYVALUE=dc8c2900-e642-488d-b5a8-a67bf70a9389" -e "PORT=8443" -e "PROTOCOL=https" -e "PROMETHEUS=9250" -e "TLSKEYPATH=/etc/bridge_ssl/certs" -e "TLSKEYFILE=privkey.pem" -e "TLSCERTFILE=cert.pem" -v /tmp:/var/log/ibm_bridge_for_grafana -v /etc/bridge_ssl/certs:/etc/bridge_ssl/certs --pod new:my-bridge-pod --name grafana_bridge bridge_image:latest
```
Run a grafana-bridge pod only for Prometheus plugin
```
# podman run -dt -p 9250:9250 -e "SERVER=9.152.187.158" -e "APIKEYVALUE=dc8c2900-e642-488d-b5a8-a67bf70a9389" -e "PROMETHEUS=9250" -e "TLSKEYPATH=/etc/bridge_ssl/certs" -e "TLSKEYFILE=privkey.pem" -e "TLSCERTFILE=cert.pem" -v /tmp:/var/log/ibm_bridge_for_grafana -v /etc/bridge_ssl/certs:/etc/bridge_ssl/certs --pod new:my-bridge-ssl-test-pod --name bridge-ssl-test scale_bridge:test_8.0.0_prometheus
```