### PR TITLE
Switch to CircleCi default remote-docker-image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,7 @@ jobs:
             . venv/bin/activate
             flake8 --max-line-length=999 --ignore=E731,E741,E712,E722,W503 --exclude=venv* --statistics
             nose2
-      - setup_remote_docker:
-          version: 20.10.17
+      - setup_remote_docker
       - run:
           name: Build Docker image
           command: |


### PR DESCRIPTION
https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176