### PR TITLE
Prometheus: SSL Optional/Overview page

### DIFF
--- a/source/confParser.py
+++ b/source/confParser.py
@@ -36,11 +36,7 @@ def checkFileExists(path, filename):
 
 
 def checkTLSsettings(args):
-    if args.get('prometheus') and (not args.get('tlsKeyPath') or not
-                                   args.get('tlsKeyFile') or not
-                                   args.get('tlsCertFile')):
-        return False, MSG['MissingSSLCert']
-    elif args.get('protocol') == "https" and (not args.get('tlsKeyPath') or not
+    if args.get('protocol') == "https" and (not args.get('tlsKeyPath') or not
                                               args.get('tlsKeyFile') or not
                                               args.get('tlsCertFile')
                                               ):


### PR DESCRIPTION
* This makes SSL optional for Prometheus (As already done for OpenTSDB), it is very common to us Prometheus exporters _without_ SSL
* Also this  adds a simple Prometheus overview when browsing the cherrypy site without any "script name"/apex (akin to well known node exporter)