### PR TITLE
Publish v8.0.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM $BASE
 
 LABEL com.ibm.name="IBM Storage Scale bridge for Grafana"
 LABEL com.ibm.vendor="IBM"
-LABEL com.ibm.version="8.0.0-dev"
+LABEL com.ibm.version="8.0.0"
 LABEL com.ibm.url="https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana"
 LABEL com.ibm.description="This tool translates the IBM Storage Scale performance data collected internally \
 to the query requests acceptable by the Grafana integrated openTSDB plugin"

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+# Version 8.0.0 (04/26/2024)
+The Grafana Bridge has been refactored to allow several APIs to be registered and run as standalone plugins. The OpenTSDB API now needs to be explicitly registered via port configuration in config.ini before it can be used with Grafana. 
+Added the new Prometheus Exporter plugin which collects metrics and exposes them in a format that can be scraped by the Prometheus timeseries database. This plugin also needs to be enabled via port configuration. 
+Added Prometheus server configuration file examples. 
+Added a Client Basic Authentication over HTTP/S support. 
+Added features to collect and report the internal performance statistics of grafana-bridge. 
+
+Tested with Grafana version 10.2.3
+Tested with RedHat community-powered Grafana operator v.5
+
+
+
 # Version 7.1.3 (03/08/2024)
 Changed the Dockerfile parent image to the registry.access.redhat.com/ubi9/ubi:9.3-1610 \
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,4 +1,15 @@
 The following matrix gives a quick overview of the supported software for the IBM Storage Scale bridge for Grafana packages by version number:
+# Version 8.0.0 (04/26/2024)
+Classic Scale:
+ - Python 3.9
+ - CherryPy 18.9.0
+ - IBM Storage Scale system must run 5.2.0 and above
+ - Grafana 10.2.3 and above
+
+ Cloud native:
+ - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.2.0
+ - RedHat community-powered Grafana-Operator v5
+ 
 # Version 7.1.3 (03/08/2024)
 Classic Scale:
  - Python 3.9

--- a/source/__version__.py
+++ b/source/__version__.py
@@ -1,6 +1,6 @@
 '''
 ##############################################################################
-# Copyright 2021 IBM Corp.
+# Copyright 2024 IBM Corp.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,4 +20,4 @@ Created on Feb 17, 2021
 @author: HWASSMAN
 '''
 
-__version__ = '8.0.0-dev'
+__version__ = '8.0.0'


### PR DESCRIPTION
The main changes of 8.0.0:
- The OpenTSDB API now needs to be explicitly registered via port configuration in config.ini before it can be used with Grafana. 
- Added the new Prometheus Exporter plugin which collects metrics and exposes them in a format that can be scraped by the  Prometheus timeseries database. This plugin also needs to be enabled via port configuration. 
- Added Prometheus server configuration file examples. 
- Added a Client Basic Authentication over HTTP/S support. 
- Added features to collect and report performance statistics about grafana-bridge itself.