### PR TITLE
Add unit service file

### DIFF
--- a/grafana-bridge.service
+++ b/grafana-bridge.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=IBM Storage Scale bridge for Grafana
+After=multi-user.target
+
+[Service]
+Type=simple
+Restart=on-failure
+WorkingDirectory=/opt/IBM/bridge
+ExecStart=/usr/bin/python3 -u source/zimonGrafanaIntf.py
+
+StandardOutput=journal+console
+StandardError=journal+console
+SyslogIdentifier=grafana-bridge
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added service unit file. This will include how to start or stop the service, under which circumstances it should be automatically started, and the dependency and ordering information for related software.
```
  cp <my-grafana-bridge-location>/grafana-bridge.service /etc/systemd/system/
  sudo systemctl daemon-reload
  sudo systemctl enable grafana-bridge.service
  sudo systemctl start grafana-bridge.service
```
resolves #207 


Signed-off-by: hwassman <hwassman@de.ibm.com>