### PR TITLE
Expose meatadata endpoints

### DIFF
--- a/source/metadata.py
+++ b/source/metadata.py
@@ -35,6 +35,7 @@ local_cache = []
 
 
 class MetadataHandler(metaclass=Singleton):
+    exposed = True
 
     def __init__(self, **kwargs):
         self.__qh = None
@@ -145,6 +146,33 @@ class MetadataHandler(metaclass=Singleton):
                 self.logger.info(MSG['ReceivAttrValues'].format('sensors', ", ".join(sensors)))
                 return
         raise ValueError(MSG['NoData'])
+
+    @cherrypy.tools.json_out()  # @UndefinedVariable
+    def GET(self, **params):
+        """ Forward GET REST HTTP/s API incoming requests to Metadata Handler
+            available endpoints:
+                            /metadata/update
+                            /metadata/sensorsconfig
+        """
+        resp = []
+
+        # /metadata/update
+        if '/metadata/update' == cherrypy.request.script_name:
+            # cherrypy.response.headers['Content-Type'] = 'application/json'
+            resp = self.update()
+            # resp = json.dumps(resp)
+
+        # /metadata/sensorsconfig
+        elif '/metadata/sensorsconfig' == cherrypy.request.script_name:
+            # cherrypy.response.headers['Content-Type'] = 'application/json'
+            resp = self.SensorsConfig
+            # resp = json.dumps(resp)
+
+        del cherrypy.response.headers['Allow']
+        cherrypy.response.headers['Access-Control-Allow-Origin'] = '*'
+        # cherrypy.response.headers['Content-Type'] = 'application/json'
+        # resp = json.dumps(resp)
+        return resp
 
     @execution_time()
     def update(self, refresh_all=False):

--- a/source/opentsdb.py
+++ b/source/opentsdb.py
@@ -293,18 +293,6 @@ class OpenTsdbApi(object):
         elif 'lookup' in cherrypy.request.script_name:
             resp = self.lookup(params)
 
-        # /api/update
-        elif 'update' in cherrypy.request.script_name:
-            # cherrypy.response.headers['Content-Type'] = 'application/json'
-            resp = self.md.update()
-            # resp = json.dumps(resp)
-
-        # /sensorsconfig
-        elif '/sensorsconfig' == cherrypy.request.script_name:
-            # cherrypy.response.headers['Content-Type'] = 'application/json'
-            resp = self.md.SensorsConfig
-            # resp = json.dumps(resp)
-
         elif 'aggregators' in cherrypy.request.script_name:
             resp = ["noop", "sum", "avg", "max", "min", "rate"]
 

--- a/source/prometheus.py
+++ b/source/prometheus.py
@@ -154,7 +154,7 @@ class PrometheusExporter(object):
             raise cherrypy.HTTPError(400, MSG[400])
 
         if self.endpoints and self.endpoints.get(cherrypy.request.script_name,
-                                                   None):
+                                                 None):
             sensor = self.endpoints[cherrypy.request.script_name]
             resp = self.metrics([sensor])
             cherrypy.response.headers['Content-Type'] = 'text/plain'

--- a/source/prometheus.py
+++ b/source/prometheus.py
@@ -153,17 +153,7 @@ class PrometheusExporter(object):
         if int(conn[1]) != int(self.port):
             raise cherrypy.HTTPError(400, MSG[400])
 
-        # /update
-        if '/update' == cherrypy.request.script_name:
-            # cherrypy.response.headers['Content-Type'] = 'application/json'
-            resp = self.md.update()
-
-        # /sensorsconfig
-        elif '/sensorsconfig' == cherrypy.request.script_name:
-            # cherrypy.response.headers['Content-Type'] = 'application/json'
-            resp = self.md.SensorsConfig
-
-        elif self.endpoints and self.endpoints.get(cherrypy.request.script_name,
+        if self.endpoints and self.endpoints.get(cherrypy.request.script_name,
                                                    None):
             sensor = self.endpoints[cherrypy.request.script_name]
             resp = self.metrics([sensor])

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -258,6 +258,19 @@ def main(argv):
         logger.error("ZiMon sensor configuration file not found")
         return
 
+    # query to force update of metadata (zimon)
+    cherrypy.tree.mount(mdHandler, '/metadata/update',
+                        {'/':
+                         {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                         }
+                        )
+    # query for list configured zimon sensors
+    cherrypy.tree.mount(mdHandler, '/metadata/sensorsconfig',
+                        {'/':
+                         {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                         }
+                        )
+
     if args.get('port', None):
         bind_opentsdb_server(args)
         api = OpenTsdbApi(logger, mdHandler, args.get('port'))
@@ -277,18 +290,6 @@ def main(argv):
                             )
         # query for tag name and value, given a metric (openTSDB)
         cherrypy.tree.mount(api, '/api/search/lookup',
-                            {'/':
-                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
-                             }
-                            )
-        # query to force update of metadata (zimon feature)
-        cherrypy.tree.mount(api, '/api/update',
-                            {'/':
-                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
-                             }
-                            )
-        # query for list configured zimon sensors
-        cherrypy.tree.mount(api, '/sensorsconfig',
                             {'/':
                              {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
                              }
@@ -316,19 +317,6 @@ def main(argv):
                                       args.get('rawCounters', False))
         exporter.endpoints.update(ENDPOINTS.get('prometheus',
                                                 {}))
-
-        # query to force update of metadata (zimon feature)
-        cherrypy.tree.mount(exporter, '/update',
-                            {'/':
-                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
-                             }
-                            )
-        # query for list configured zimon sensors
-        cherrypy.tree.mount(exporter, '/sensorsconfig',
-                            {'/':
-                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
-                             }
-                            )
         # query for all metrics (PrometheusExporter)
         cherrypy.tree.mount(exporter, '/metrics',
                             {'/':
@@ -343,8 +331,9 @@ def main(argv):
                                      }
                                     )
         registered_apps.append("Prometheus Exporter Api listening on Prometheus requests")
+
     profiler = Profiler(args.get('logPath'))
-    # query for list configured zimon sensors
+    # query for print out profiling report
     cherrypy.tree.mount(profiler, '/profiling',
                         {'/':
                          {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}


### PR DESCRIPTION
Expose endpoints for querying and updating zimon configuration data. 
All zimon configuration related endpoints are mounted on the /metadata route.

Available endpoints:
```
/metadata/update
/metadata/sensorsconfig
```