### PR TITLE
Add plugin for generating Promtheus config file authomatically 

### DIFF
--- a/source/confgenerator.py
+++ b/source/confgenerator.py
@@ -1,0 +1,142 @@
+'''
+##############################################################################
+# Copyright 2023 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+Created on Mai 30, 2024
+
+@author: HWASSMAN
+'''
+
+import cherrypy
+import json
+import socket
+import os
+try:
+    # Optional dependency
+    import yaml
+except ImportError as e:
+    yaml = e
+import analytics
+from messages import MSG, ERR
+
+
+class PrometheusConfigGenerator(object):
+    exposed = True
+
+    def __init__(self, logger, mdHandler, config_attr, endpoints):
+        if isinstance(yaml, ImportError):
+            raise yaml
+        self.logger = logger
+        self.__md = mdHandler
+        self.endpoints = endpoints
+        self.attr = config_attr
+
+    @property
+    def md(self):
+        return self.__md
+
+    @property
+    def qh(self):
+        return self.__md.qh
+
+    @property
+    def TOPO(self):
+        return self.__md.metaData
+
+    @staticmethod
+    def host_ip():
+        hostname = socket.getfqdn()
+        local_ip = socket.gethostbyname_ex(hostname)[2][0]
+        return local_ip
+
+    def generate_config(self):
+        scrape_configs = []
+        global_config = {"scrape_interval": "15s",
+                         "evaluation_interval": "15s",
+                         "query_log_file": "/var/log/prometheus/query.log"}
+        alerting_config = {"alertmanagers": [{"static_configs": [{"targets": None}]}]}
+        for endpoint, sensor in self.endpoints.items():
+            period = self.md.getSensorPeriod(sensor)
+            if period > 0:
+                scrape_job = {}
+                scrape_job["job_name"] = sensor
+                scrape_job["scrape_interval"] = f"{period}s"
+                scrape_job["honor_timestamps"] = True
+                scrape_job["metrics_path"] = endpoint
+                scrape_job["scheme"] = self.attr.get('protocol')
+                if self.attr.get('tlsKeyPath'):
+                    certPath = os.path.join(self.attr.get('tlsKeyPath'),
+                                            self.attr.get('tlsCertFile'))
+                    keyPath = os.path.join(self.attr.get('tlsKeyPath'),
+                                           self.attr.get('tlsKeyFile'))
+                    tls = {"cert_file": certPath,
+                           "key_file": keyPath,
+                           "insecure_skip_verify": True}
+                    scrape_job["tls_config"] = tls
+                if self.attr.get('enabled', False):
+                    basic_auth = {"username": self.attr.get('username'),
+                                  "password": self.attr.get('password')}
+                    scrape_job["basic_auth"] = basic_auth
+                targets = {"targets": [f"{self.host_ip()}:{self.attr.get('prometheus')}"]}
+                scrape_job["static_configs"] = [targets]
+                scrape_configs.append(scrape_job)
+        prometheus_job = {}
+        prometheus_job["job_name"] = "prometheus"
+        prometheus_job["static_configs"] = [{"targets": ["localhost:9090"]}]
+        scrape_configs.insert(0, prometheus_job)
+        resp = {"global": global_config,
+                "alerting": alerting_config,
+                "rule_files": None,
+                "scrape_configs": scrape_configs}
+        yaml_string = yaml.dump(resp)
+        return yaml_string
+
+    def GET(self, **params):
+        '''Handle partial URLs such as /metrics_cpu
+           TODO: add more explanation
+        '''
+        resp = []
+
+        conn = cherrypy.request.headers.get('Host').split(':')
+        if int(conn[1]) != int(self.attr.get('prometheus')):
+            raise cherrypy.HTTPError(400, ERR[400])
+
+        # generate prometheus.yml
+        if '/prometheus.yml' == cherrypy.request.script_name:
+            print(params)
+            resp = self.generate_config()
+            cherrypy.response.headers['Content-Type'] = 'text/plain'
+            return resp
+
+        else:
+            self.logger.error(MSG['EndpointNotSupported'].format(cherrypy.request.script_name))
+            raise cherrypy.HTTPError(400,
+                                     MSG['EndpointNotSupported'].format(
+                                         cherrypy.request.script_name))
+
+        del cherrypy.response.headers['Allow']
+        cherrypy.response.headers['Access-Control-Allow-Origin'] = '*'
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        resp = json.dumps(resp)
+        return resp
+
+    def OPTIONS(self):
+        # print('options_post')
+        del cherrypy.response.headers['Allow']
+        cherrypy.response.headers['Access-Control-Allow-Methods'] = 'GET, POST, NEW, OPTIONS'
+        cherrypy.response.headers['Access-Control-Allow-Origin'] = '*'
+        cherrypy.response.headers['Access-Control-Allow-Headers'] = 'Content-Type,Accept'
+        cherrypy.response.headers['Access-Control-Max-Age'] = 604800

--- a/source/confgenerator.py
+++ b/source/confgenerator.py
@@ -29,7 +29,6 @@ try:
     import yaml
 except ImportError as e:
     yaml = e
-import analytics
 from messages import MSG, ERR
 
 

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -35,6 +35,7 @@ from __version__ import __version__
 from messages import ERR, MSG
 from bridgeLogger import configureLogging, getBridgeLogger
 from confParser import getSettings
+from confgenerator import PrometheusConfigGenerator
 from metadata import MetadataHandler
 from opentsdb import OpenTsdbApi
 from prometheus import PrometheusExporter
@@ -258,6 +259,7 @@ def main(argv):
         logger.error("ZiMon sensor configuration file not found")
         return
 
+    # register MetaData Handler endpoints
     # query to force update of metadata (zimon)
     cherrypy.tree.mount(mdHandler, '/metadata/update',
                         {'/':
@@ -271,6 +273,7 @@ def main(argv):
                          }
                         )
 
+    # register OpenTSDB API endpoints
     if args.get('port', None):
         bind_opentsdb_server(args)
         api = OpenTsdbApi(logger, mdHandler, args.get('port'))
@@ -308,6 +311,7 @@ def main(argv):
                             )
         registered_apps.append("OpenTSDB Api listening on Grafana queries")
 
+    # register Prometheus Exporter API endpoints
     if args.get('prometheus', None):
         bind_prometheus_server(args)
         load_endpoints('prometheus_endpoints.json')
@@ -332,6 +336,22 @@ def main(argv):
                                     )
         registered_apps.append("Prometheus Exporter Api listening on Prometheus requests")
 
+        # register Prometheus config generator endpoints (only if PyYaml available)
+        try:
+            conf_generator = PrometheusConfigGenerator(logger,
+                                                   mdHandler,
+                                                   args,
+                                                   ENDPOINTS.get('prometheus',{}))
+            cherrypy.tree.mount(conf_generator, '/prometheus.yml',
+                                {'/':
+                                 {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                                 }
+                                )
+            registered_apps.append("Prometheus Config Generator Api")
+        except ImportError as e:
+            logger.warning("Prometheus Config Generator Api requires python PyYaml packages. Skip registering API.")
+
+    # register Profiler reporter endpoint
     profiler = Profiler(args.get('logPath'))
     # query for print out profiling report
     cherrypy.tree.mount(profiler, '/profiling',
@@ -339,8 +359,15 @@ def main(argv):
                          {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
                          }
                         )
+
+    # register cherrypy stats plugin endpoint
     if analytics.cherrypy_internal_stats:
-        cherrypy.tree.mount(StatsPage(), '/cherrypy_internal_stats')
+        cherrypy.tree.mount(StatsPage(), '/cherrypy_internal_stats',
+                            {'/':
+                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                             }
+                            )
+
     logger.info("%s", MSG['sysStart'].format(sys.version, cherrypy.__version__))
 
     try:

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -339,16 +339,16 @@ def main(argv):
         # register Prometheus config generator endpoints (only if PyYaml available)
         try:
             conf_generator = PrometheusConfigGenerator(logger,
-                                                   mdHandler,
-                                                   args,
-                                                   ENDPOINTS.get('prometheus',{}))
+                                                       mdHandler,
+                                                       args,
+                                                       ENDPOINTS.get('prometheus', {}))
             cherrypy.tree.mount(conf_generator, '/prometheus.yml',
                                 {'/':
                                  {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
                                  }
                                 )
             registered_apps.append("Prometheus Config Generator Api")
-        except ImportError as e:
+        except ImportError:
             logger.warning("Prometheus Config Generator Api requires python PyYaml packages. Skip registering API.")
 
     # register Profiler reporter endpoint

--- a/tests/test_confgenerator.py
+++ b/tests/test_confgenerator.py
@@ -2,7 +2,6 @@ import logging
 import os
 from unittest import mock
 from nose2.tools.decorators import with_setup
-from source.queryHandler.QueryHandler import ColumnInfo, Key
 from source.profiler import Profiler
 from source.metadata import MetadataHandler
 from source.confgenerator import PrometheusConfigGenerator
@@ -68,7 +67,7 @@ def test_case01():
     with mock.patch('source.metadata.MetadataHandler._MetadataHandler__initializeTables') as md_init:
         with mock.patch('source.metadata.MetadataHandler._MetadataHandler__getSupportedMetrics') as md_supp:
             with mock.patch('source.metadata.MetadataHandler.SensorsConfig', return_value=sensors_conf) as md_sensConf:
-                with mock.patch('source.confgenerator.PrometheusConfigGenerator.host_ip', return_value='127.0.0.1') as pc_ip:
+                with mock.patch('source.confgenerator.PrometheusConfigGenerator.host_ip', return_value='127.0.0.1'):
                     logger = logging.getLogger(__name__)
                     args['logger'] = logger
                     md = MetadataHandler(**args)
@@ -86,7 +85,7 @@ def test_case02():
     with mock.patch('source.metadata.MetadataHandler._MetadataHandler__initializeTables') as md_init:
         with mock.patch('source.metadata.MetadataHandler._MetadataHandler__getSupportedMetrics') as md_supp:
             with mock.patch('source.metadata.MetadataHandler.SensorsConfig', return_value=sensors_conf) as md_sensConf:
-                with mock.patch('source.confgenerator.PrometheusConfigGenerator.host_ip', return_value='127.0.0.1') as pc_ip:
+                with mock.patch('source.confgenerator.PrometheusConfigGenerator.host_ip', return_value='127.0.0.1'):
                     logger = logging.getLogger(__name__)
                     args['logger'] = logger
                     md = MetadataHandler(**args)

--- a/tests/test_confgenerator.py
+++ b/tests/test_confgenerator.py
@@ -1,0 +1,103 @@
+import logging
+import os
+from unittest import mock
+from nose2.tools.decorators import with_setup
+from source.queryHandler.QueryHandler import ColumnInfo, Key
+from source.profiler import Profiler
+from source.metadata import MetadataHandler
+from source.confgenerator import PrometheusConfigGenerator
+
+
+def my_setup():
+    global attr, args, endpoints, sensors_conf
+
+    attr = {'port': 4242, 'prometheus': 9250, 'rawCounters': True, 'protocol': 'http', 'enabled': True,
+            'username': 'scale_admin', 'password': 'TXlWZXJ5U3Ryb25nUGFzc3cwcmQhCg==', 'server': 'localhost',
+            'serverPort': 9980, 'retryDelay': 60, 'apiKeyName': 'scale_grafana',
+            'apiKeyValue': 'c0a910e4-094a-46d8-b04d-c2f73a43fd17', 'caCertPath': False,
+            'includeDiskData': False, 'logPath': '/var/log/ibm_bridge_for_grafana', 'logLevel': 10,
+            'logFile': 'zserver.log'}
+    args = {'server': 'localhost', 'port': 9980, 'retryDelay': 60,
+            'apiKeyName': 'scale_grafana',
+            'apiKeyValue': 'c0a910e4-094a-46d8-b04d-c2f73a43fd17'}
+
+    endpoints = {"/metrics_gpfs_disk": "GPFSDisk",
+                 "/metrics_gpfs_filesystem": "GPFSFilesystem",
+                 "//metrics_gpfs_fileset": "GPFSFileset",
+                 "/metrics_gpfs_pool": "GPFSPool"}
+
+    sensors_conf = [{'name': '"CPU"', 'period': '1'},
+                    {'name': '"Load"', 'period': '1'},
+                    {'name': '"Memory"', 'period': '1'},
+                    {'filter': '"netdev_name=veth.*|docker.*|flannel.*|cali.*|cbr.*"',
+                     'name': '"Network"', 'period': '1'},
+                    {'name': '"Netstat"', 'period': '10'},
+                    {'name': '"Diskstat"', 'period': '0'},
+                    {'filter': '"mountPoint=/.*/docker.*|/.*/kubelet.*"', 'name': '"DiskFree"', 'period': '600'},
+                    {'name': '"Infiniband"', 'period': '0'},
+                    {'name': '"GPFSDisk"', 'period': '0'},
+                    {'name': '"GPFSFilesystem"', 'period': '10'},
+                    {'name': '"GPFSNSDDisk"', 'period': '10', 'restrict': '"nsdNodes"'},
+                    {'name': '"GPFSPoolIO"', 'period': '0'}, {'name': '"GPFSVFSX"', 'period': '10'},
+                    {'name': '"GPFSIOC"', 'period': '0'}, {'name': '"GPFSVIO64"', 'period': '0'},
+                    {'name': '"GPFSPDDisk"', 'period': '10', 'restrict': '"nsdNodes"'},
+                    {'name': '"GPFSvFLUSH"', 'period': '0'}, {'name': '"GPFSNode"', 'period': '10'},
+                    {'name': '"GPFSNodeAPI"', 'period': '10'}, {'name': '"GPFSFilesystemAPI"', 'period': '10'},
+                    {'name': '"GPFSLROC"', 'period': '0'}, {'name': '"GPFSCHMS"', 'period': '0'},
+                    {'name': '"GPFSAFM"', 'period': '10', 'restrict': '"scale-16.vmlocal,scale-17.vmlocal"'},
+                    {'name': '"GPFSAFMFS"', 'period': '10', 'restrict': '"scale-16.vmlocal,scale-17.vmlocal"'},
+                    {'name': '"GPFSAFMFSET"', 'period': '10', 'restrict': '"scale-16.vmlocal,scale-17.vmlocal"'},
+                    {'name': '"GPFSRPCS"', 'period': '10'}, {'name': '"GPFSWaiters"', 'period': '10'},
+                    {'name': '"GPFSFilesetQuota"', 'period': '3600', 'restrict': '"@CLUSTER_PERF_SENSOR"'},
+                    {'name': '"GPFSFileset"', 'period': '300', 'restrict': '"@CLUSTER_PERF_SENSOR"'},
+                    {'name': '"GPFSPool"', 'period': '300', 'restrict': '"@CLUSTER_PERF_SENSOR"'},
+                    {'name': '"GPFSDiskCap"', 'period': '86400', 'restrict': '"@CLUSTER_PERF_SENSOR"'},
+                    {'name': '"GPFSEventProducer"', 'period': '0'}, {'name': '"GPFSMutex"', 'period': '0'},
+                    {'name': '"GPFSCondvar"', 'period': '0'}, {'name': '"TopProc"', 'period': '60'},
+                    {'name': '"GPFSQoS"', 'period': '0'}, {'name': '"GPFSFCM"', 'period': '0'},
+                    {'name': '"GPFSBufMgr"', 'period': '30'},
+                    {'name': '"NFSIO"', 'period': '10', 'restrict': '"cesNodes"', 'type': '"Generic"'},
+                    {'name': '"SMBStats"', 'period': '1', 'restrict': '"cesNodes"', 'type': '"Generic"'},
+                    {'name': '"SMBGlobalStats"', 'period': '1', 'restrict': '"cesNodes"', 'type': '"Generic"'},
+                    {'name': '"CTDBStats"', 'period': '1', 'restrict': '"cesNodes"', 'type': '"Generic"'},
+                    {'name': '"CTDBDBStats"', 'period': '1', 'restrict': '"cesNodes"', 'type': '"Generic"'}]
+
+
+@with_setup(my_setup)
+def test_case01():
+    with mock.patch('source.metadata.MetadataHandler._MetadataHandler__initializeTables') as md_init:
+        with mock.patch('source.metadata.MetadataHandler._MetadataHandler__getSupportedMetrics') as md_supp:
+            with mock.patch('source.metadata.MetadataHandler.SensorsConfig', return_value=sensors_conf) as md_sensConf:
+                with mock.patch('source.confgenerator.PrometheusConfigGenerator.host_ip', return_value='127.0.0.1') as pc_ip:
+                    logger = logging.getLogger(__name__)
+                    args['logger'] = logger
+                    md = MetadataHandler(**args)
+                    md.__initializeTables = md_init.return_value
+                    md.__getSupportedMetrics = md_supp.return_value
+                    md.SensorsConfig = md_sensConf.return_value
+                    conf_generator = PrometheusConfigGenerator(logger, md, attr, endpoints)
+                    resp = conf_generator.generate_config()
+                    assert isinstance(resp, str)
+                    assert len(resp) > 0
+
+
+@with_setup(my_setup)
+def test_case02():
+    with mock.patch('source.metadata.MetadataHandler._MetadataHandler__initializeTables') as md_init:
+        with mock.patch('source.metadata.MetadataHandler._MetadataHandler__getSupportedMetrics') as md_supp:
+            with mock.patch('source.metadata.MetadataHandler.SensorsConfig', return_value=sensors_conf) as md_sensConf:
+                with mock.patch('source.confgenerator.PrometheusConfigGenerator.host_ip', return_value='127.0.0.1') as pc_ip:
+                    logger = logging.getLogger(__name__)
+                    args['logger'] = logger
+                    md = MetadataHandler(**args)
+                    md.__initializeTables = md_init.return_value
+                    md.__getSupportedMetrics = md_supp.return_value
+                    md.SensorsConfig = md_sensConf.return_value
+                    conf_generator = PrometheusConfigGenerator(logger, md, attr, endpoints)
+                    profiler = Profiler()
+                    resp = profiler.run(conf_generator.generate_config)
+                    assert resp is not None
+                    assert os.path.exists(os.path.join(profiler.path, "profiling_generate_config.prof"))
+                    response = profiler.stats(os.path.join(profiler.path, "profiling_generate_config.prof"))
+                    assert response is not None
+                    print('\n'.join(response) + '\n')


### PR DESCRIPTION
Prometheus Server requires a configuration file with a list of scrape targets from which to collect metrics. 
The content of this file will be automatically pre-generated based on supported endpoints and their sensor data by calling the 
endpoint '/prometheus.yml'