### PR TITLE
Disable running grafana-bridge 8.0.x with Python <3.8

### DIFF
--- a/source/profiler.py
+++ b/source/profiler.py
@@ -24,7 +24,12 @@ import cherrypy
 import io
 import os
 from cProfile import Profile
-from pstats import SortKey, Stats
+try:
+    # Optional dependency
+    from pstats import SortKey
+except ImportError as e:
+    SortKey = e
+from pstats import Stats
 from metaclasses import Singleton
 
 
@@ -32,6 +37,8 @@ class Profiler(metaclass=Singleton):
     exposed = True
 
     def __init__(self, path=None):
+        if isinstance(SortKey, ImportError):
+            raise SortKey
         if not path:
             path = os.path.join(os.path.dirname(__file__), 'profile')
         self.path = path

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -208,6 +208,17 @@ def main(argv):
         print(msg)
         return
 
+    if sys.version < '3.8':
+        print(f'\nYor system running {sys.version} \n\nThe IBM Storage Scale bridge for Grafana requires Python3.8 or above. \
+        \nRead the following instructions for possible solution: \
+        \nhttps://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/wiki/What-to-do-if-your-system-is-on-a-Python-version-lower-than-3.8')
+        return
+
+    if __version__.endswith('-dev'):
+        print(f'\n Warning: You are running a Development version of the IBM Storage Scale bridge for Grafana. \
+        \n It is recommended to use the latest released version, published on: \
+        \n https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/releases \n')
+
     registered_apps = []
 
     if args.get('enabled', False):

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -215,7 +215,7 @@ def main(argv):
         return
 
     if __version__.endswith('-dev'):
-        print(f'\n Warning: You are running a Development version of the IBM Storage Scale bridge for Grafana. \
+        print('\n Warning: You are running a Development version of the IBM Storage Scale bridge for Grafana. \
         \n It is recommended to use the latest released version, published on: \
         \n https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/releases \n')
 


### PR DESCRIPTION
The latest grafana-bridge requires at least Python3.8 (Recommended Python3.9).

If the Python requirements are not met, the bridge will stop with the following warning:
```
[root@scale-21 source]# python3 zimonGrafanaIntf.py

Yor system running 3.6.8 (default, Jan 23 2023, 22:31:05)
[GCC 8.5.0 20210514 (Red Hat 8.5.0-18)]

The IBM Storage Scale bridge for Grafana requires Python3.8 or above.
Read the following instructions for possible solution:
https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/wiki/What-to-do-if-your-system-is-on-a-Python-version-lower-than-3.8
``` 
Older versions of the grafana bridge still support Python3.6 and above.