### PR TITLE
Fix Python version comparison issue

### DIFF
--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -208,8 +208,7 @@ def main(argv):
         print(msg)
         return
 
-    print(sys.version_info >= (3,8))
-    if (sys.version_info < (3,8)):
+    if (sys.version_info < (3, 8)):
         print(f'\nYor system running {sys.version} \n\nThe IBM Storage Scale bridge for Grafana requires Python3.8 or above. \
         \nRead the following instructions for possible solution: \
         \nhttps://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/wiki/What-to-do-if-your-system-is-on-a-Python-version-lower-than-3.8')

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -208,7 +208,8 @@ def main(argv):
         print(msg)
         return
 
-    if sys.version < '3.8':
+    print(sys.version_info >= (3,8))
+    if (sys.version_info < (3,8)):
         print(f'\nYor system running {sys.version} \n\nThe IBM Storage Scale bridge for Grafana requires Python3.8 or above. \
         \nRead the following instructions for possible solution: \
         \nhttps://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana/wiki/What-to-do-if-your-system-is-on-a-Python-version-lower-than-3.8')


### PR DESCRIPTION
Resolves the following issue:
```
# python3.11 zimonGrafanaIntf.py

Yor system running 3.11.2 (main, Feb 17 2023, 09:28:16) [GCC 8.5.0 20210514 (Red Hat 8.5.0-18)]

The IBM Storage Scale bridge for Grafana requires Python3.8 or above.
```