### PR TITLE
Publish fileset quota reporting dashboard examples

### DIFF
--- a/examples/grafana_dashboards/gpfs_fileset_quotas/Fileset Block Quota Limits details-1721846218751.json
+++ b/examples/grafana_dashboards/gpfs_fileset_quotas/Fileset Block Quota Limits details-1721846218751.json
@@ -1,0 +1,287 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VM2-CLUSTER1",
+      "label": "vm2-cluster1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opentsdb",
+      "pluginName": "OpenTSDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opentsdb",
+      "name": "OpenTSDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "description": "This Graph based on the metrics of the GPFSFilesetQuota sensor. The time series vizualization shows the number of currently used kilobytes in relation to the assigned soft and hard quota limit of the  byFileset from the $byFilesystem.\n\n**Note**  that the GPFSFilesetQuota sensor is running once per hour. \n\nUsed metrics:\ngpfs_rq_blk_current: Number of kilobytes currently in use.\ngpfs_rq_blk_soft_limit: Assigned soft quota limit.\ngpfs_rq_blk_hard_limit: Assigned hard quota limit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "noValue": "NaN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "deckbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 23,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "current capacity usage",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFileset",
+              "groupBy": false,
+              "tagk": "gpfs_fset_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_rq_blk_current",
+          "refId": "A"
+        },
+        {
+          "aggregator": "noop",
+          "alias": "soft limit",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFileset",
+              "groupBy": false,
+              "tagk": "gpfs_fset_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_rq_blk_soft_limit",
+          "refId": "B"
+        },
+        {
+          "aggregator": "noop",
+          "alias": "hard limit",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFileset",
+              "groupBy": false,
+              "tagk": "gpfs_fset_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_rq_blk_hard_limit",
+          "refId": "C"
+        }
+      ],
+      "title": "$byFileset block usage and limits",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "fileset",
+    "capacity",
+    "quota"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "vm2-cluster1",
+          "value": "cdqnnhu44hjb4b"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "System",
+        "options": [],
+        "query": "opentsdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFilesystem",
+        "options": [],
+        "query": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_rq_blk_current, gpfs_fset_name, gpfs_fs_name=$byFilesystem)\n",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFileset",
+        "options": [],
+        "query": "tag_values(gpfs_rq_blk_current, gpfs_fset_name, gpfs_fs_name=$byFilesystem)\n",
+        "refresh": 1,
+        "regex": "^(?!.*root).*$",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fileset Block Quota Limits details",
+  "uid": "bdr84zexhhm9sd",
+  "version": 9,
+  "weekStart": ""
+}

--- a/examples/grafana_dashboards/gpfs_fileset_quotas/Fileset Inode Quota Limits details-1721846244963.json
+++ b/examples/grafana_dashboards/gpfs_fileset_quotas/Fileset Inode Quota Limits details-1721846244963.json
@@ -1,0 +1,286 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VM2-CLUSTER1",
+      "label": "vm2-cluster1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opentsdb",
+      "pluginName": "OpenTSDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opentsdb",
+      "name": "OpenTSDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "noValue": "NaN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 23,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "current inode usage",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFileset",
+              "groupBy": false,
+              "tagk": "gpfs_fset_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_rq_file_current",
+          "refId": "A"
+        },
+        {
+          "aggregator": "noop",
+          "alias": "soft limit",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFileset",
+              "groupBy": false,
+              "tagk": "gpfs_fset_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_rq_file_soft_limit",
+          "refId": "B"
+        },
+        {
+          "aggregator": "noop",
+          "alias": "hard limit",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFileset",
+              "groupBy": false,
+              "tagk": "gpfs_fset_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_rq_file_hard_limit",
+          "refId": "C"
+        }
+      ],
+      "title": "$byFileset files(inodes) usage and limits",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "fileset",
+    "inode",
+    "quota"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "vm2-cluster1",
+          "value": "cdqnnhu44hjb4b"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "System",
+        "options": [],
+        "query": "opentsdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFilesystem",
+        "options": [],
+        "query": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_rq_blk_current, gpfs_fset_name)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFileset",
+        "options": [],
+        "query": "tag_values(gpfs_rq_blk_current, gpfs_fset_name)",
+        "refresh": 1,
+        "regex": "^(?!.*root).*$",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fileset Inode Quota Limits details",
+  "uid": "bdr8l18sqz280c",
+  "version": 4,
+  "weekStart": ""
+}

--- a/examples/grafana_dashboards/gpfs_fileset_quotas/Fileset Quota Limits-1721846026221.json
+++ b/examples/grafana_dashboards/gpfs_fileset_quotas/Fileset Quota Limits-1721846026221.json
@@ -1,0 +1,1372 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VM2-CLUSTER1",
+      "label": "vm2-cluster1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opentsdb",
+      "pluginName": "OpenTSDB"
+    },
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
+    }
+  ],
+  "__elements": {
+    "fdr9fzl70hhq8c": {
+      "name": "Capacity Utilization per Fileset (soft limit) in $byFilesystem",
+      "uid": "fdr9fzl70hhq8c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "description": "This Graph based on the metrics of the GPFSFilesetQuota sensor. The bar diagram shows the number of currently used kilobytes in relation to the assigned soft quota limit per fileset of the $byFilesystem.\n\n**Note**  that the GPFSFilesetQuota sensor is running once per hour. \n\nThe percentage value is calculated as follows:\n(gpfs_rq_blk_current + gpfs_rq_blk_in_doubt)/gpfs_rq_blk_soft_limit from gpfs_fs_name=$byFilesystem\n",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "green",
+              "mode": "continuous-GrYlRd"
+            },
+            "decimals": 1,
+            "displayName": "${__field.labels.gpfs_fset_name}",
+            "fieldMinMax": false,
+            "mappings": [],
+            "max": 1,
+            "noValue": "NaN",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "options": {
+          "displayMode": "lcd",
+          "maxVizHeight": 200,
+          "minVizHeight": 50,
+          "minVizWidth": 75,
+          "namePlacement": "top",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "manual",
+          "text": {
+            "titleSize": 15,
+            "valueSize": 30
+          },
+          "valueMode": "color"
+        },
+        "pluginVersion": "11.0.0",
+        "targets": [
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_blk_current",
+            "refId": "D"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_blk_in_doubt",
+            "refId": "A"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_blk_soft_limit",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "($D+$A)/$B",
+            "hide": false,
+            "refId": "C",
+            "type": "math"
+          }
+        ],
+        "title": "Capacity Utilization per Fileset (soft limit) in $byFilesystem",
+        "transformations": [
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "pattern": "^(?!.*root).*$"
+              }
+            }
+          }
+        ],
+        "type": "bargauge"
+      }
+    },
+    "adrg9886nbi80d": {
+      "name": "Inode utilization per Fileset (soft limit) in $byFilesystem",
+      "uid": "adrg9886nbi80d",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "description": "This Graph based on the metrics of the GPFSFilesetQuota sensor. The bar diagram shows the number of currently used  files (inodes) in relation to the assigned soft quota limit per fileset of the $byFilesystem.\n\n**Note**  that the GPFSFilesetQuota sensor is running once per hour. \n\nThe percentage value is calculated as follows:\n(gpfs_rq_file_current+gpfs_rq_file_in_doubt) /gpfs_rq_file_soft_limit from gpfs_fs_name=$byFilesystem",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "green",
+              "mode": "shades"
+            },
+            "decimals": 1,
+            "displayName": "${__field.labels.gpfs_fset_name}",
+            "fieldMinMax": false,
+            "mappings": [],
+            "max": 1,
+            "noValue": "NaN",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 19922944
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "options": {
+          "displayMode": "lcd",
+          "maxVizHeight": 200,
+          "minVizHeight": 50,
+          "minVizWidth": 75,
+          "namePlacement": "top",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "manual",
+          "text": {
+            "titleSize": 15,
+            "valueSize": 30
+          },
+          "valueMode": "color"
+        },
+        "pluginVersion": "11.0.0",
+        "targets": [
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "iliteral_or"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_file_current",
+            "refId": "D"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "iliteral_or"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_file_in_doubt",
+            "refId": "A"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_file_soft_limit",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "($D+$A)/$B",
+            "hide": false,
+            "refId": "C",
+            "type": "math"
+          }
+        ],
+        "title": "Inode utilization per Fileset (soft limit) in $byFilesystem",
+        "transformations": [
+          {
+            "filter": {
+              "id": "byRefId",
+              "options": "C"
+            },
+            "id": "sortBy",
+            "options": {}
+          },
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "pattern": "^(?!.*root).*$"
+              }
+            }
+          }
+        ],
+        "type": "bargauge"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "__expr__",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opentsdb",
+      "name": "OpenTSDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This dashboard could be used to monitor file system usage and quota information per file set.\n",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "**Additional info:**           If the panels on the left side do not show any data, please quickly scroll down and up the entire dashboard.\r\n                               After reading this message, you can remove this text panel from the dashboard entirely.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.0.0",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "This graph is based on the metrics provided by the GPFSFilesetQuota sensor. The table shows the top 5 $byFilesystem filesets with the highest kilobyte usage based on the assigned soft quota limit.\n\n**Note that the GPFSFilesetQuota sensor runs once per hour. \n\nThe percentage is calculated as follows\nmax(gpfs_rq_blk_current /gpfs_rq_blk_soft_limit) from gpfs_fs_name=$byFilesystem.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": false,
+            "inspect": false,
+            "minWidth": 50
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "show details",
+              "url": "/../d/bdr84zexhhm9sd/fileset-block-quota-limits-details?orgId=1&refresh=5s&var-byFileset=${__data.fields.gpfs_fset_name}&var-byFilesystem=${__data.fields.gpfs_fs_name}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 40
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Field"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gpfs_cluster_name"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gpfs_fs_name"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gpfs_fset_name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 2
+      },
+      "id": 6,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "show all",
+          "url": "/../d/fdr9h7kvfypdsb/filesets-block-limits?&var-byFilesystem=$byFilesystem"
+        }
+      ],
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Max"
+          }
+        ]
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 3,
+          "refId": "A",
+          "withTransforms": false
+        }
+      ],
+      "title": "Top 5 filesets approaching the soft block quotas",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "labelsToFields": true,
+            "reducers": [
+              "max"
+            ]
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Max"
+              }
+            ]
+          }
+        },
+        {
+          "id": "limit",
+          "options": {
+            "limitField": 5
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "^(?!.*root).*$"
+                  }
+                },
+                "fieldName": "gpfs_fset_name"
+              }
+            ],
+            "match": "all",
+            "type": "include"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "description": "This Graph based on GPFSFilesetQuota sensor metric gpfs_rq_blk_current.\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 54,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "deckbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 13,
+        "x": 6,
+        "y": 2
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "metric": "gpfs_rq_blk_current",
+          "refId": "A"
+        }
+      ],
+      "title": "The amount of disk space (kilobytes) currently in use",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "description": "This Graph based on the metrics of the GPFSDiskCap sensor.\n\n**Note**  that the GPFSDiskCap sensor is running once per day. \n In the first 24h after the filesystem creation there will be probably no value shown. \n\nThe percentage value is calculated as follows:\nsum(gpfs_disk_disksize) - (sum(gpfs_disk_free_fullkb) ) /sum(gpfs_disk_disksize) from gpfs_fs_name=$byFilesystem\n\nClick on the value in the graph to switch to the detail view.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "show details",
+              "url": "/../d/cdr9jtyc56qdcf/filesystem-disk-capacity-overview?var-byFilesystem=${__field.labels.gpfs_fs_name}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 2
+      },
+      "id": 11,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto",
+        "text": {}
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_disk_free_fullkb",
+          "refId": "A"
+        },
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_disk_disksize",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "($B-$A)/$B",
+          "hide": false,
+          "refId": "C",
+          "type": "math"
+        }
+      ],
+      "title": "$byFilesystem disk capacity usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "This graph is based on the metrics provided by the GPFSFilesetQuota sensor. The table shows the top 5 $byFilesystem filesets with the highest inodes(files) usage based on the assigned soft quota limit.\n\n**Note that the GPFSFilesetQuota sensor runs once per hour. \n\nThe percentage is calculated as follows\nmax(gpfs_rq_file_current /gpfs_rq_file_soft_limit) from gpfs_fs_name=$byFilesystem.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": false,
+            "inspect": false,
+            "minWidth": 50
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "show details",
+              "url": "/../d/bdr8l18sqz280c/fileset-inode-quota-limits-details?orgId=1&refresh=5s&var-byFileset=${__data.fields.gpfs_fset_name}&var-byFilesystem=${__data.fields.gpfs_fs_name}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 40
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Field"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gpfs_cluster_name"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gpfs_fs_name"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gpfs_fset_name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "id": 10,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "show all",
+          "url": "/../d/fdrg9bidhv1tsa/filesets-inode-limits?&var-byFilesystem=$byFilesystem"
+        }
+      ],
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Max"
+          }
+        ]
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 14,
+          "refId": "A",
+          "withTransforms": false
+        }
+      ],
+      "title": "Top 5 filesets approaching the soft file quotas",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "labelsToFields": true,
+            "reducers": [
+              "max"
+            ]
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Max"
+              }
+            ]
+          }
+        },
+        {
+          "id": "limit",
+          "options": {
+            "limitField": 5
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "^(?!.*root).*$"
+                  }
+                },
+                "fieldName": "gpfs_fset_name"
+              }
+            ],
+            "match": "all",
+            "type": "include"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 54,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 13,
+        "x": 6,
+        "y": 10
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "metric": "gpfs_rq_file_current",
+          "refId": "A"
+        }
+      ],
+      "title": "Sum of files (inodes) currently in use",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "description": "This Graph based on the metrics of the GPFSInodeCap sensor.\n\n**Note** that the GPFSInodeCap is not an independent sensor in the perfmon config, \nbut a sub-sensor of the GPFSDiskCap sensor which is running once per day. \nIn the first 24h after the filesystem creation there will be probably no value shown. \n\nThe percentage value is calculated as follows:\ngpfs_fs_inode_used /gpfs_fs_inode_max from gpfs_fs_name=$byFilesystem\n\nClick on the value in the graph to switch to the detail view.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "",
+              "url": "/../d/cdrgckceicl4wf/filesystem-inodes-overview?var-byFilesystem=${__field.labels.gpfs_fs_name}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 80
+              },
+              {
+                "color": "dark-red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 10
+      },
+      "id": 12,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_fs_inode_used",
+          "refId": "A"
+        },
+        {
+          "aggregator": "noop",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_fs_inode_max",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A/$B",
+          "hide": false,
+          "refId": "C",
+          "type": "math"
+        }
+      ],
+      "title": "$byFilesystem inode capacity usage",
+      "type": "gauge"
+    },
+    {
+      "gridPos": {
+        "h": 15,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 3,
+      "libraryPanel": {
+        "uid": "fdr9fzl70hhq8c",
+        "name": "Capacity Utilization per Fileset (soft limit) in $byFilesystem"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 15,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 14,
+      "libraryPanel": {
+        "uid": "adrg9886nbi80d",
+        "name": "Inode utilization per Fileset (soft limit) in $byFilesystem"
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "capacity",
+    "fileset",
+    "quota"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "vm2-cluster1",
+          "value": "cdqnnhu44hjb4b"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "System",
+        "options": [],
+        "query": "opentsdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "description": "List filesystems with enforced per-fileset quotas.\nIf a specific filesystem name is not on the list, use `mmlsfs <fs> -Q' to check if per-fileset quotas are enforced.",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFilesystem",
+        "options": [],
+        "query": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fileset Quota Limits",
+  "uid": "bdbb60a6-b34d-4fcf-944f-9c0715021127",
+  "version": 105,
+  "weekStart": ""
+}

--- a/examples/grafana_dashboards/gpfs_fileset_quotas/Filesystem disk capacity overview-1721846054460.json
+++ b/examples/grafana_dashboards/gpfs_fileset_quotas/Filesystem disk capacity overview-1721846054460.json
@@ -1,0 +1,453 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
+    },
+    {
+      "name": "DS_VM2-CLUSTER1",
+      "label": "vm2-cluster1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opentsdb",
+      "pluginName": "OpenTSDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "__expr__",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opentsdb",
+      "name": "OpenTSDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This dashboard can be used to monitor the available disk space on the selected GPFS file system.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "icon": "external link",
+      "tags": [
+        "home"
+      ],
+      "type": "dashboards"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "$byCluster"
+      },
+      "description": "This Graph based on the metrics of the GPFSDiskCap sensor.\n\n**Note**  that the GPFSDiskCap sensor is running once per day. \n In the first 24h after the filesystem creation there will be probably no value shown. \n\nThe total capacity value is calculated as follows:\nsum(gpfs_disk_disksize) from gpfs_fs_name=$byFilesystem\n",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "kbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "sum",
+          "alias": "$tag_gpfs_fs_name",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterType": "literal_or",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": true,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "metric": "gpfs_disk_disksize",
+          "refId": "A"
+        }
+      ],
+      "title": "$byFilesystem total capacity",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "$byCluster"
+      },
+      "description": "This Graph based on the metrics of the GPFSDiskCap sensor.\n\n**Note**  that the GPFSDiskCap sensor is running once per day. \n In the first 24h after the filesystem creation there will be probably no value shown. \n\nThe free capacity value  per disk(NSD) is calculated as follows:\ngpfs_disk_free_fullkb from gpfs_fs_name=$byFilesystem\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "deckbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 15,
+        "x": 6,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 114,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "$tag_gpfs_disk_name",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_disk_free_fullkb",
+          "refId": "B"
+        }
+      ],
+      "title": "$byFilesystem free capacity per disk(NSD)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "$byCluster"
+      },
+      "description": "This Graph based on the metrics of the GPFSDiskCap sensor.\n\n**Note**  that the GPFSDiskCap sensor is running once per day. \n In the first 24h after the filesystem creation there will be probably no value shown. \n\nThe percentage value is calculated as follows:\nsum(gpfs_disk_free_fullkb) /sum(gpfs_disk_disksize) from gpfs_fs_name=$byFilesystem\n\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "sum",
+          "alias": "",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterType": "literal_or",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": true,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_disk_free_fullkb",
+          "refId": "A"
+        },
+        {
+          "aggregator": "sum",
+          "alias": "",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterType": "literal_or",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": true,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_disk_disksize",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A/$B",
+          "hide": false,
+          "refId": "C",
+          "type": "math"
+        }
+      ],
+      "title": "$byFilesystem free capacity utilization",
+      "type": "gauge"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "NSD",
+    "capacity",
+    "filesystem"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "vm2-cluster1",
+          "value": "cdqnnhu44hjb4b"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "select cluster",
+        "multi": false,
+        "name": "byCluster",
+        "options": [],
+        "query": "opentsdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_disk_free_fullkb, gpfs_fs_name)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFilesystem",
+        "options": [],
+        "query": "tag_values(gpfs_disk_free_fullkb, gpfs_fs_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Filesystem disk capacity overview",
+  "uid": "cdr9jtyc56qdcf",
+  "version": 16,
+  "weekStart": ""
+}

--- a/examples/grafana_dashboards/gpfs_fileset_quotas/Filesystem inodes overview-1721846097425.json
+++ b/examples/grafana_dashboards/gpfs_fileset_quotas/Filesystem inodes overview-1721846097425.json
@@ -1,0 +1,452 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
+    },
+    {
+      "name": "DS_VM2-CLUSTER1",
+      "label": "vm2-cluster1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opentsdb",
+      "pluginName": "OpenTSDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "__expr__",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opentsdb",
+      "name": "OpenTSDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This dashboard can be used to monitor the inode usage of independent file sets in the selected filesystem.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "icon": "external link",
+      "tags": [
+        "home"
+      ],
+      "type": "dashboards"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "$byCluster"
+      },
+      "description": "The total inodes value in $byFilesystem is calculated as follows:\ngpfs_fs_inode_max from gpfs_fs_name=$byFilesystem",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "$tag_gpfs_fs_name",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterType": "literal_or",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": true,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "metric": "gpfs_fs_inode_max",
+          "refId": "A"
+        }
+      ],
+      "title": "$byFilesystem max number of inodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "$byCluster"
+      },
+      "description": "This Graph based on the metrics of the GPFSFileset sensor.\n\n**Note**  that the GPFSDiskCap sensor is running every 5 min. \n\n\nThe allocated inodes per independent fileset in $byFilesystem is calculated as follows:\ngpfs_fset_allocInodes  from gpfs_fs_name=$byFilesystem",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 18,
+        "x": 6,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 114,
+        "minVizWidth": 0,
+        "namePlacement": "left",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "sizing": "auto",
+        "text": {
+          "titleSize": 10
+        },
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "$tag_gpfs_fset_name",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": false,
+          "metric": "gpfs_fset_allocInodes",
+          "refId": "B"
+        }
+      ],
+      "title": "$byFilesystem allocated inodes per fileset",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "$byCluster"
+      },
+      "description": "This Graph based on the metrics of the GPFSInodeCap sensor.\n\n**Note** that the GPFSInodeCap is not an independent sensor in the perfmon config, but a sub-sensor of the GPFSDiskCap sensor.\nThe GPFSDiskCap sensor is running once per day. \n In the first 24h after the filesystem creation there will be probably no value shown. \n\nThe percentage value is calculated as follows:\nsum(gpfs_fs_inode_free) /sum(gpfs_fs_inode_max) from gpfs_fs_name=$byFilesystem",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterType": "literal_or",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": true,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_fs_inode_free",
+          "refId": "A"
+        },
+        {
+          "aggregator": "noop",
+          "alias": "",
+          "currentFilterGroupBy": false,
+          "currentFilterKey": "",
+          "currentFilterType": "literal_or",
+          "currentFilterValue": "",
+          "datasource": {
+            "uid": "$byCluster"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": true,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_fs_inode_max",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A/$B",
+          "hide": false,
+          "refId": "C",
+          "type": "math"
+        }
+      ],
+      "title": "$byFilesystem free inode utilization",
+      "type": "gauge"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "fileset",
+    "filesystem",
+    "inode"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "vm2-cluster1",
+          "value": "cdqnnhu44hjb4b"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "select cluster",
+        "multi": false,
+        "name": "byCluster",
+        "options": [],
+        "query": "opentsdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_disk_free_fullkb, gpfs_fs_name)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFilesystem",
+        "options": [],
+        "query": "tag_values(gpfs_disk_free_fullkb, gpfs_fs_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Filesystem inodes overview",
+  "uid": "cdrgckceicl4wf",
+  "version": 14,
+  "weekStart": ""
+}

--- a/examples/grafana_dashboards/gpfs_fileset_quotas/filesets block limits-1721846141639.json
+++ b/examples/grafana_dashboards/gpfs_fileset_quotas/filesets block limits-1721846141639.json
@@ -1,0 +1,438 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VM2-CLUSTER1",
+      "label": "vm2-cluster1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opentsdb",
+      "pluginName": "OpenTSDB"
+    },
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
+    }
+  ],
+  "__elements": {
+    "fdr9fzl70hhq8c": {
+      "name": "Capacity Utilization per Fileset (soft limit) in $byFilesystem",
+      "uid": "fdr9fzl70hhq8c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "description": "This Graph based on the metrics of the GPFSFilesetQuota sensor. The bar diagram shows the number of currently used kilobytes in relation to the assigned soft quota limit per fileset of the $byFilesystem.\n\n**Note**  that the GPFSFilesetQuota sensor is running once per hour. \n\nThe percentage value is calculated as follows:\n(gpfs_rq_blk_current + gpfs_rq_blk_in_doubt)/gpfs_rq_blk_soft_limit from gpfs_fs_name=$byFilesystem\n",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "green",
+              "mode": "continuous-GrYlRd"
+            },
+            "decimals": 1,
+            "displayName": "${__field.labels.gpfs_fset_name}",
+            "fieldMinMax": false,
+            "mappings": [],
+            "max": 1,
+            "noValue": "NaN",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "options": {
+          "displayMode": "lcd",
+          "maxVizHeight": 200,
+          "minVizHeight": 50,
+          "minVizWidth": 75,
+          "namePlacement": "top",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "manual",
+          "text": {
+            "titleSize": 15,
+            "valueSize": 30
+          },
+          "valueMode": "color"
+        },
+        "pluginVersion": "11.0.0",
+        "targets": [
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_blk_current",
+            "refId": "D"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_blk_in_doubt",
+            "refId": "A"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_blk_soft_limit",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "($D+$A)/$B",
+            "hide": false,
+            "refId": "C",
+            "type": "math"
+          }
+        ],
+        "title": "Capacity Utilization per Fileset (soft limit) in $byFilesystem",
+        "transformations": [
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "pattern": "^(?!.*root).*$"
+              }
+            }
+          }
+        ],
+        "type": "bargauge"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "__expr__",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opentsdb",
+      "name": "OpenTSDB",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This dashboard provides an overview of the capacity usage and quota information per file set of the selected file system.\nCompare the data with the output of the `mmrepquota -j <fs>' command.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 21,
+        "w": 10,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "libraryPanel": {
+        "uid": "fdr9fzl70hhq8c",
+        "name": "Capacity Utilization per Fileset (soft limit) in $byFilesystem"
+      }
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "description": "This Graph based on the metrics of the GPFSFilesetQuota sensor.  The bar diagram shows the number of currently used kilobytes in relation to the assigned hard quota limit per fileset of the $byFilesystem.\n\n**Note**  that the GPFSFilesetQuota sensor is running once per hour. \n\nThe percentage value is calculated as follows:\ngpfs_rq_blk_current /gpfs_rq_blk_hard_limit from gpfs_fs_name=$byFilesystem",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "continuous-GrYlRd"
+          },
+          "decimals": 1,
+          "displayName": "${__field.labels.gpfs_fset_name}",
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 1,
+          "noValue": "NaN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 21,
+        "w": 10,
+        "x": 11,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 200,
+        "minVizHeight": 50,
+        "minVizWidth": 75,
+        "namePlacement": "top",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "manual",
+        "text": {
+          "titleSize": 15,
+          "valueSize": 30
+        },
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "$tag_gpfs_fset_name",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_rq_blk_current",
+          "refId": "A"
+        },
+        {
+          "aggregator": "noop",
+          "alias": "$tag_gpfs_fset_name",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_rq_blk_hard_limit",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A/$B",
+          "hide": false,
+          "refId": "C",
+          "type": "math"
+        }
+      ],
+      "title": "Capacity Utilization per Fileset (hard limit) in $byFilesystem",
+      "transformations": [
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "C"
+          },
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "C {gpfs_cluster_name=\"scale-cluster-1.vmlocal\", gpfs_fs_name=\"localFS\", gpfs_fset_name=\"localFileset1\"}"
+              }
+            ]
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(?!.*root).*$"
+            }
+          }
+        }
+      ],
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "fileset",
+    "capacity",
+    "quota"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "vm2-cluster1",
+          "value": "cdqnnhu44hjb4b"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "System",
+        "options": [],
+        "query": "opentsdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFilesystem",
+        "options": [],
+        "query": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "filesets block limits",
+  "uid": "fdr9h7kvfypdsb",
+  "version": 10,
+  "weekStart": ""
+}

--- a/examples/grafana_dashboards/gpfs_fileset_quotas/filesets inode limits-1721846178985.json
+++ b/examples/grafana_dashboards/gpfs_fileset_quotas/filesets inode limits-1721846178985.json
@@ -1,0 +1,446 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VM2-CLUSTER1",
+      "label": "vm2-cluster1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opentsdb",
+      "pluginName": "OpenTSDB"
+    },
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
+    }
+  ],
+  "__elements": {
+    "adrg9886nbi80d": {
+      "name": "Inode utilization per Fileset (soft limit) in $byFilesystem",
+      "uid": "adrg9886nbi80d",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "description": "This Graph based on the metrics of the GPFSFilesetQuota sensor. The bar diagram shows the number of currently used  files (inodes) in relation to the assigned soft quota limit per fileset of the $byFilesystem.\n\n**Note**  that the GPFSFilesetQuota sensor is running once per hour. \n\nThe percentage value is calculated as follows:\n(gpfs_rq_file_current+gpfs_rq_file_in_doubt) /gpfs_rq_file_soft_limit from gpfs_fs_name=$byFilesystem",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "green",
+              "mode": "shades"
+            },
+            "decimals": 1,
+            "displayName": "${__field.labels.gpfs_fset_name}",
+            "fieldMinMax": false,
+            "mappings": [],
+            "max": 1,
+            "noValue": "NaN",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 19922944
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "options": {
+          "displayMode": "lcd",
+          "maxVizHeight": 200,
+          "minVizHeight": 50,
+          "minVizWidth": 75,
+          "namePlacement": "top",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "manual",
+          "text": {
+            "titleSize": 15,
+            "valueSize": 30
+          },
+          "valueMode": "color"
+        },
+        "pluginVersion": "11.0.0",
+        "targets": [
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "iliteral_or"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_file_current",
+            "refId": "D"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "iliteral_or"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_file_in_doubt",
+            "refId": "A"
+          },
+          {
+            "aggregator": "noop",
+            "alias": "$tag_gpfs_fset_name",
+            "datasource": {
+              "type": "opentsdb",
+              "uid": "${System}"
+            },
+            "disableDownsampling": true,
+            "downsampleAggregator": "noop",
+            "downsampleFillPolicy": "none",
+            "filters": [
+              {
+                "filter": "$byFilesystem",
+                "groupBy": false,
+                "tagk": "gpfs_fs_name",
+                "type": "pm_filter"
+              }
+            ],
+            "hide": true,
+            "metric": "gpfs_rq_file_soft_limit",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "($D+$A)/$B",
+            "hide": false,
+            "refId": "C",
+            "type": "math"
+          }
+        ],
+        "title": "Inode utilization per Fileset (soft limit) in $byFilesystem",
+        "transformations": [
+          {
+            "filter": {
+              "id": "byRefId",
+              "options": "C"
+            },
+            "id": "sortBy",
+            "options": {}
+          },
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "pattern": "^(?!.*root).*$"
+              }
+            }
+          }
+        ],
+        "type": "bargauge"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "__expr__",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opentsdb",
+      "name": "OpenTSDB",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 25,
+        "w": 11,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "libraryPanel": {
+        "uid": "adrg9886nbi80d",
+        "name": "Inode utilization per Fileset (soft limit) in $byFilesystem"
+      }
+    },
+    {
+      "datasource": {
+        "type": "opentsdb",
+        "uid": "${DS_VM2-CLUSTER1}"
+      },
+      "description": "This Graph based on the metrics of the GPFSFilesetQuota sensor. The bar diagram shows the number of currently used  files (inodes) in relation to the assigned hard quota limit per fileset of the $byFilesystem.\n\n**Note**  that the GPFSFilesetQuota sensor is running once per hour. \n\nThe percentage value is calculated as follows:\ngpfs_rq_file_current /gpfs_rq_file_hard_limit from gpfs_fs_name=$byFilesystem",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "shades"
+          },
+          "decimals": 1,
+          "displayName": "${__field.labels.gpfs_fset_name}",
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 1,
+          "noValue": "NaN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 19922944
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 25,
+        "w": 11,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 200,
+        "minVizHeight": 50,
+        "minVizWidth": 75,
+        "namePlacement": "top",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "manual",
+        "text": {
+          "titleSize": 15,
+          "valueSize": 30
+        },
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "aggregator": "noop",
+          "alias": "$tag_gpfs_fset_name",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "iliteral_or"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_rq_file_current",
+          "refId": "A"
+        },
+        {
+          "aggregator": "noop",
+          "alias": "$tag_gpfs_fset_name",
+          "datasource": {
+            "type": "opentsdb",
+            "uid": "${DS_VM2-CLUSTER1}"
+          },
+          "disableDownsampling": true,
+          "downsampleAggregator": "noop",
+          "downsampleFillPolicy": "none",
+          "filters": [
+            {
+              "filter": "$byFilesystem",
+              "groupBy": false,
+              "tagk": "gpfs_fs_name",
+              "type": "pm_filter"
+            }
+          ],
+          "hide": true,
+          "metric": "gpfs_rq_file_hard_limit",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A/$B",
+          "hide": false,
+          "refId": "C",
+          "type": "math"
+        }
+      ],
+      "title": "Inode utilization per Fileset (hard limit) in $byFilesystem",
+      "transformations": [
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "C"
+          },
+          "id": "sortBy",
+          "options": {}
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(?!.*root).*$"
+            }
+          }
+        }
+      ],
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "fileset",
+    "inode",
+    "quota"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "vm2-cluster1",
+          "value": "cdqnnhu44hjb4b"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "System",
+        "options": [],
+        "query": "opentsdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "opentsdb",
+          "uid": "${DS_VM2-CLUSTER1}"
+        },
+        "definition": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "description": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)\n\n",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "byFilesystem",
+        "options": [],
+        "query": "tag_values(gpfs_rq_blk_current, gpfs_fs_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "filesets inode limits",
+  "uid": "fdrg9bidhv1tsa",
+  "version": 14,
+  "weekStart": ""
+}


### PR DESCRIPTION
This bundle of dashboards provides the customer with the ability to monitor the capacity and inode usage in the independent file sets against the assigned soft and hard limits.