### PR TITLE
Publish v7.2.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM $BASE
 
 LABEL com.ibm.name="IBM Storage Scale bridge for Grafana"
 LABEL com.ibm.vendor="IBM"
-LABEL com.ibm.version="7.1.9"
+LABEL com.ibm.version="7.2.0"
 LABEL com.ibm.url="https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana"
 LABEL com.ibm.description="This tool translates the IBM Storage Scale performance data collected internally \
 to the query requests acceptable by the Grafana integrated openTSDB plugin"

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+# Version 7.2.0 (12/06/2024)
+Changed the Dockerfile parent image to the registry.access.redhat.com/ubi9/ubi:9.5-1732804088 \
+Speed up OpenTSDB /search/lookup REST Api endpoint response time \
+Backported important fixes that improve overall bridge performance \
+
+Tested with Grafana version 11
+Tested with RedHat community-powered Grafana operator v.5
+
+
+
 # Version 7.1.9 (09/27/2024)
 Changed the Dockerfile parent image to the registry.access.redhat.com/ubi9/ubi:9.4-1214.1726694543 \
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,4 +1,16 @@
 The following matrix gives a quick overview of the supported software for the IBM Storage Scale bridge for Grafana packages by version number:
+# Version 7.2.0 (12/06/2024)
+Classic Scale:
+ - Python 3.9
+ - CherryPy 18.10.0
+ - IBM Storage Scale system must run 5.1.9 and above
+ - Grafana 11.0.0 and above
+ 
+ Cloud native:
+ - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.1.9.8,5.2.2.1
+ - RedHat community-powered Grafana-Operator v5
+
+
 # Version 7.1.9 (09/27/2024)
 Classic Scale:
  - Python 3.9

--- a/source/__version__.py
+++ b/source/__version__.py
@@ -20,4 +20,4 @@ Created on Feb 17, 2021
 @author: HWASSMAN
 '''
 
-__version__ = '7.1.9'
+__version__ = '7.2.0'


### PR DESCRIPTION
Major changes:
Changed the Dockerfile parent image to the registry.access.redhat.com/ubi9/ubi:9.5-1732804088 \
Speed up OpenTSDB /search/lookup REST Api endpoint response time \
Backported important fixes that improve overall bridge performance 