### PR TITLE
Rework Dockerfile allowing build grafana-bridge image from Redhat UBI9/Python3.9 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
+ARG BUILD_ENV=prod
 ARG BASE=registry.access.redhat.com/ubi9/ubi:9.5-1732804088
-FROM $BASE
+
+FROM $BASE as build_prod
+ONBUILD COPY ./requirements/requirements_ubi9.txt  /root/requirements_ubi9.txt
+
+FROM $BASE as build_test
+ONBUILD COPY ./requirements/requirements_ubi.in  /root/requirements_ubi.in
+
+FROM $BASE as build_custom
+ONBUILD COPY ./requirements/requirements.in  /root/requirements.in
+
+FROM build_${BUILD_ENV}
+
+ARG BUILD_ENV
+ARG BASE
 
 LABEL com.ibm.name="IBM Storage Scale bridge for Grafana"
 LABEL com.ibm.vendor="IBM"
@@ -26,11 +40,9 @@ ENV GID=$GROUPID
 
 ARG HTTPPROTOCOL=http
 ENV PROTOCOL=$HTTPPROTOCOL
-RUN echo "the HTTP/S protocol is set to $PROTOCOL"
 
 ARG HTTPBASICAUTH=True
 ENV BASICAUTH=$HTTPBASICAUTH
-RUN echo "the HTTP/S basic authentication is set to $BASICAUTH"
 
 ARG AUTHUSER=None
 ENV BASICAUTHUSER=$AUTHUSER
@@ -40,15 +52,12 @@ ENV BASICAUTHPASSW=$AUTHPASSW
 
 ARG HTTPPORT=None
 ENV PORT=$HTTPPORT
-RUN echo "the OpentTSDB API HTTP/S port is set to $PORT"
 
 ARG PROMPORT=None
-ENV PROMETHEUS=$PROMPORT
-RUN echo "the Prometheus API HTTPS port is set to $PROMETHEUS" 
+ENV PROMETHEUS=$PROMPORT 
 
 ARG PERFMONPORT=9980
 ENV SERVERPORT=$PERFMONPORT
-RUN echo "the PERFMONPORT port is set to $SERVERPORT" 
 
 ARG CERTPATH='/etc/bridge_ssl/certs'
 ENV TLSKEYPATH=$CERTPATH
@@ -67,27 +76,33 @@ ENV APIKEYVALUE=$KEYVALUE
 
 ARG PMCOLLECTORIP=0.0.0.0
 ENV SERVER=$PMCOLLECTORIP
-RUN echo "the pmcollector server ip is set to $SERVER"
 
 ARG DEFAULTLOGPATH='/var/log/ibm_bridge_for_grafana'
 ENV LOGPATH=$DEFAULTLOGPATH
-RUN echo "the log will use $LOGPATH"
 
 ARG DEFAULTLOGLEVEL=15
 ENV LOGLEVEL=$DEFAULTLOGLEVEL
 
-COPY ./requirements/requirements_ubi9.txt  /root/requirements_ubi9.txt
-# COPY ./requirements/requirements_ubi.in  /root/requirements_ubi.in
-
-RUN yum install -y python39 python3-pip
-
-# RUN /usr/bin/python3 -m pip install pip-tools && \
-#     /usr/bin/python3 -m piptools compile /root/requirements_ubi.in  --output-file /root/requirements_ubi9.txt && \
-#     echo "Compiled python packages: $(cat /root/requirements_ubi9.txt)"
-
-RUN /usr/bin/python3 -m pip install -r /root/requirements_ubi9.txt && \
-    echo "Installed python version: $(/usr/bin/python3 -V)" && \
-    echo "Installed python packages: $(/usr/bin/python3 -m pip list)"
+RUN echo "the HTTP/S protocol is set to $PROTOCOL"  && \
+    echo "the HTTP/S basic authentication is set to $BASICAUTH"  && \
+    echo "the OpentTSDB API HTTP/S port is set to $PORT"  && \
+    echo "the Prometheus API HTTPS port is set to $PROMETHEUS"  && \
+    echo "the PERFMONPORT port is set to $SERVERPORT" && \
+    echo "the pmcollector server ip is set to $SERVER" && \
+    echo "the log will use $LOGPATH" 
+	
+RUN if [ $(expr "$BASE" : '.*python.*') -eq 0 ]; then \
+	yum install -y python39 python3-pip; \
+	if [ "$BUILD_ENV" = "build_test" ]; then \             
+	python3 -m pip install pip-tools && \
+	python3 -m piptools compile /root/requirements_ubi.in  --output-file /root/requirements_ubi9.txt && \
+	echo "Compiled python packages: $(cat /root/requirements_ubi9.txt)"; fi && \
+	python3 -m pip install -r /root/requirements_ubi9.txt && \
+        echo "Installed python version: $(python3 -V)" && \
+        echo "Installed python packages: $(python3 -m pip list)"; else \
+	echo "Already using python container as base image. No need to install it." && \ 
+	python3 -m pip install  -r /root/requirements.in && \
+	echo "Installed python packages: $(python3 -m pip list)"; fi
 
 USER root
 
@@ -101,8 +116,8 @@ COPY ./source/gpfsConfig/mmsdrfs* /var/mmfs/gen/
 COPY ./source/gpfsConfig/ZIMon* /opt/IBM/zimon/
 
 RUN if [ "${APIKEYVALUE:0:1}" = "/" ]; then ln -s $APIKEYVALUE /etc/perfmon-api-keys; echo "APIKEYVALUE is a PATH"; else echo "APIKEYVALUE not a PATH"; fi && \
-    if [ -z "$TLSKEYPATH" ] || [ -z "$TLSCERTFILE" ] || [ -z "$TLSKEYFILE" ] && [ "$PROTOCOL" = "https" ]; then echo "TLSKEYPATH FOR SSL CONNECTION NOT SET - ERROR"; exit 1; else echo "PASS"; fi
-RUN echo "the ssl certificates path is set to $TLSKEYPATH" 
+    if [ -z "$TLSKEYPATH" ] || [ -z "$TLSCERTFILE" ] || [ -z "$TLSKEYFILE" ] && [ "$PROTOCOL" = "https" ]; then echo "TLSKEYPATH FOR SSL CONNECTION NOT SET - ERROR"; exit 1; else echo "PASS"; fi && \
+    echo "the ssl certificates path is set to $TLSKEYPATH" 
 
 # Switch to the working directory
 WORKDIR /opt/IBM/bridge

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,0 +1,14 @@
+# This file is used for generating python requirements list "requirements.txt".
+# It includes the packages needed to be installed to run the IBM Storage Scale Performance Monitoring bridge for Grafana
+# on top of the Redhat ubi9/python-39 image.
+#
+# To update, run:
+#
+#  $ pip-compile requirements_ubi.in  --output-file requirements.txt
+#
+# setuptools
+cherrypy
+PyYAML
+# psutil
+# urllib3
+requests

--- a/requirements/requirements_ubi.in
+++ b/requirements/requirements_ubi.in
@@ -1,6 +1,6 @@
 # This file is used for generating python requirements list "requirements_ubi9.txt".
 # It includes the packages needed to be installed to run the IBM Storage Scale Performance Monitoring bridge for Grafana
-# in an OpenShift production environment, on top of the redhat UBI8 image.
+# in an OpenShift production environment, on top of the Redhat UBI9 image.
 #
 # To update, run:
 #


### PR DESCRIPTION
Exampe usage:

```
# podman build --format=docker -t bridge_from_ubi:1.0_prod .
# podman build --format=docker --build-arg=BUILD_ENV=test -t bridge_from_ubi:1.1_test .
# podman build --format=docker --build-arg=BASE=python-39:9.5-1736743782 \
               --build-arg=BUILD_ENV=custom -t bridge_from_python:1.0_custom .
```