### PR TITLE
Minor Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG BUILD_ENV=prod
 ARG BASE=registry.access.redhat.com/ubi9/ubi:9.5-1736404036
 
-FROM $BASE as build_prod
+FROM $BASE AS build_prod
 ONBUILD COPY ./requirements/requirements_ubi9.txt  /root/requirements_ubi9.txt
 
-FROM $BASE as build_test
+FROM $BASE AS build_test
 ONBUILD COPY ./requirements/requirements_ubi.in  /root/requirements_ubi.in
 
-FROM $BASE as build_custom
+FROM $BASE AS build_custom
 ONBUILD COPY ./requirements/requirements.in  /root/requirements.in
 
 FROM build_${BUILD_ENV}
@@ -23,8 +23,8 @@ LABEL com.ibm.description="This tool translates the IBM Storage Scale performanc
 to the query requests acceptable by the Grafana integrated openTSDB plugin"
 LABEL com.ibm.summary="It allows the IBM Storage Scale users to perform performance monitoring for IBM Storage Scale devices using Grafana"
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 
 ARG USERNAME=bridge
 ENV USER=$USERNAME


### PR DESCRIPTION
Minor Dockerfile fixes : 

docker build --no-cache -t bridge_image:8.0.3 .

```bash
[...]
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 7)
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 10)
```

```bash
 2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 27)
```