### PR TITLE
Make usage of  --configFile argument in systemd service

### DIFF
--- a/grafana-bridge.service
+++ b/grafana-bridge.service
@@ -6,7 +6,7 @@ After=multi-user.target
 Type=simple
 Restart=on-failure
 WorkingDirectory=/opt/IBM/bridge
-ExecStart=/usr/bin/python3 -u source/zimonGrafanaIntf.py
+ExecStart=/usr/bin/python3 -u source/zimonGrafanaIntf.py --configFile source/config.ini
 
 StandardOutput=journal+console
 StandardError=journal+console

--- a/source/confParser.py
+++ b/source/confParser.py
@@ -200,7 +200,7 @@ class ConfigManager(object, metaclass=Singleton):
         """
 
         default_sections, defaults = self.parse_file(self.templateFile)
-        if not self.customFile:
+        if not self.customFile or self.customFile == self.templateFile:
             return defaults
 
         custom_sections, customs = self.parse_file(self.customFile)

--- a/tests/test_configManager.py
+++ b/tests/test_configManager.py
@@ -47,11 +47,8 @@ def test_case03():
 @with_setup(my_setup)
 def test_case04():
     customFile = os.path.join(path, "tests", "test_data", customConfigFile)
-    print(customFile)
     cm = ConfigManager()
     cm.customFile = customFile
-    print(cm.__dict__)
-    assert (cm.customFile == customFile)
     result = cm.readConfigFile(cm.customFile)
     assert 'tls' in result.keys()
 


### PR DESCRIPTION
Per default grafana-bridge parses configuration settings from source/config.ini file.
The arg --configFile allows to parse configuration from a "custom" file.
Per default the grafana-bridge.service will point to config.ini file, as default but could be overwritten for individual case.
```
ExecStart=/usr/bin/python3 -u source/zimonGrafanaIntf.py --configFile /opt/custom.ini
```