### PR TITLE
Fix reduce dps values algorithm

### DIFF
--- a/source/collector.py
+++ b/source/collector.py
@@ -117,7 +117,7 @@ class MetricTimeSeries(object):
     def __format__(self, spec):
         return f'{self.mname}_mTS'
 
-    def str_descfmt(self, original_counters=False) -> [str]:
+    def str_descfmt(self) -> [str]:
         """Format MetricTimeSeries description rows
             Output format:
                 '''# HELP {name} {desc}'''

--- a/source/prometheus.py
+++ b/source/prometheus.py
@@ -61,10 +61,10 @@ class PrometheusExporter(object):
     def format_response(self, data) -> [str]:
         resp = []
         for name, metric in data.items():
-            header = metric.str_descfmt(original_counters=self.raw_data)
+            header = metric.str_descfmt()
             resp.extend(header)
             for sts in metric.timeseries:
-                if self.raw_data:
+                if len(sts.dps) > 1:
                     sts.reduce_dps_to_first_not_none(reverse_order=True)
                 for _key, _value in sts.dps.items():
                     sts_resp = SingleTimeSeriesResponse(name, _key,


### PR DESCRIPTION
Even if the 'rawCounters' are set to false, sensors with the 'Counter' metric type will still be queried with the 'Original Data' flag.
Therefore, the 'reduce_dps_to_first_not_none' method should be invoked independently of the 'rawCounters' setting.