### PR TITLE
Publish overworked 8.0.7 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG BASE
 
 LABEL com.ibm.name="IBM Storage Scale bridge for Grafana"
 LABEL com.ibm.vendor="IBM"
-LABEL com.ibm.version="8.0.8-dev"
+LABEL com.ibm.version="8.0.8"
 LABEL com.ibm.url="https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana"
 LABEL com.ibm.description="This tool translates the IBM Storage Scale performance data collected internally \
 to the query requests acceptable by the Grafana integrated openTSDB plugin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG BASE
 
 LABEL com.ibm.name="IBM Storage Scale bridge for Grafana"
 LABEL com.ibm.vendor="IBM"
-LABEL com.ibm.version="8.0.8"
+LABEL com.ibm.version="8.0.7"
 LABEL com.ibm.url="https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana"
 LABEL com.ibm.description="This tool translates the IBM Storage Scale performance data collected internally \
 to the query requests acceptable by the Grafana integrated openTSDB plugin"

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Version 8.0.7 (08/14/2025)
+# Version 8.0.7 (09/01/2025)
 Published example dashboards for monitoring ESS Hardware metrics with Prometheus: \
 - ESS Hardware Performance overview \
 - HW Components Temperature \

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,5 +1,5 @@
 The following matrix gives a quick overview of the supported software for the IBM Storage Scale bridge for Grafana packages by version number:
-# Version 8.0.7 (08/14/2025)
+# Version 8.0.7 (09/01/2025)
 Classic Scale:
  - Python 3.9
  - CherryPy 18.10.0

--- a/source/__version__.py
+++ b/source/__version__.py
@@ -20,4 +20,4 @@ Created on Feb 17, 2021
 @author: HWASSMAN
 '''
 
-__version__ = '8.0.8-dev'
+__version__ = '8.0.7'


### PR DESCRIPTION
The main changes of 8.0.7:
Published example dashboards for monitoring ESS Hardware metrics with Prometheus
Added support for Prometheus scrape job params config
Added GPFSEvents, GPFSEXPEL, GPFSEXPELNODE sensors to PrometheusExporter supported sensors
Added helpful HTTP REST API endpoints for working with PrometheusExporter:
Modified handling of config file allowing to store and invoke custom config file outside the repository
Fix the issue with PrometheusExporter handling the 'counter' type metric when rawCounters is set to false.