### PR TITLE
Switch to latest orb version for circleci/python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
 version: 2.1
 orbs:
   python: circleci/python@3.0.0
-  tag: "3.11.14"
 jobs:
   build-and-test:
-    executor: python/default
+    executor: 
+      name: python/default
+      tag: "3.11.14"
     working_directory: ~/ibm-spectrum-scale-bridge-for-grafana
     steps:
       - checkout


### PR DESCRIPTION
- Update orb version to circleci/python@3.0.0
   https://circleci.com/developer/orbs/orb/circleci/python

- Use python version "3.11.14" during the tests
   list of supported versions could be found here: https://github.com/CircleCI-Public/cimg-python