### PR TITLE
Publish v9.0.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG BASE
 
 LABEL com.ibm.name="IBM Storage Scale bridge for Grafana"
 LABEL com.ibm.vendor="IBM"
-LABEL com.ibm.version="9.0.0-dev"
+LABEL com.ibm.version="9.0.0"
 LABEL com.ibm.url="https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana"
 LABEL com.ibm.description="This tool translates the IBM Storage Scale performance data collected internally \
 to the query requests acceptable by the Grafana integrated openTSDB plugin"

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+# Version 9.0.0 (10/30/2025)
+Added example yaml files to configure Openshift ServiceMonitor for a scale cluster running outside of this Openshift cluster
+Expanded configuration parameters to allow grafana-bridge socket host to bind to ip of specific network interface
+Removed python3.9 support, set required minimum level to 3.11
+Changed the Dockerfile parent image to the registry.access.redhat.com/ubi10/ubi:10.0-1760519443 
+
+Tested with OpenTSDB version 2.4
+Tested with Grafana version 12.0.0
+Tested with RedHat community-powered Grafana operator v.5
+
+
+
 # Version 8.1.0 (10/24/2025)
 Added check for empty/not acceptable values in the configuration file
 Changed the Dockerfile parent image to the registry.access.redhat.com/ubi9/ubi:9.6-1760340943 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,4 +1,16 @@
 The following matrix gives a quick overview of the supported software for the IBM Storage Scale bridge for Grafana packages by version number:
+# Version 9.0.0 (10/30/2025)
+Classic Scale:
+ - Python 3.12
+ - CherryPy 18.10.0
+ - IBM Storage Scale system must run 6.0.0 and above
+ - Grafana 12.0.0 and above
+ - OpenTSDB 2.4
+
+  Cloud native:
+ - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 6.0.0.1
+ - RedHat community-powered Grafana-Operator v5
+
 # Version 8.1.0 (10/24/2025)
 Classic Scale:
  - Python 3.9
@@ -6,6 +18,10 @@ Classic Scale:
  - IBM Storage Scale system must run 5.2.2 and above
  - Grafana 12.0.0 and above
  - OpenTSDB 2.4
+
+ Cloud native:
+ - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.2.3
+ - RedHat community-powered Grafana-Operator v5
 
 # Version 8.0.9 (09/01/2025)
 Classic Scale:
@@ -15,6 +31,10 @@ Classic Scale:
  - Grafana 12.0.0 and above
  - OpenTSDB 2.4
 
+ Cloud native:
+ - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.2.3
+ - RedHat community-powered Grafana-Operator v5
+
 # Version 8.0.8 (09/01/2025)
 Classic Scale:
  - Python 3.9
@@ -23,6 +43,10 @@ Classic Scale:
  - Grafana 12.0.0 and above
  - OpenTSDB 2.4
 
+ Cloud native:
+ - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.2.3
+ - RedHat community-powered Grafana-Operator v5
+
 # Version 8.0.7 (08/14/2025)
 Classic Scale:
  - Python 3.9
@@ -30,6 +54,10 @@ Classic Scale:
  - IBM Storage Scale system must run 5.2.2 and above
  - Grafana 12.0.0 and above
  - OpenTSDB 2.4
+
+ Cloud native:
+ - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.2.3
+ - RedHat community-powered Grafana-Operator v5
 
 # Version 8.0.6 (05/28/2025)
 Classic Scale:
@@ -42,7 +70,7 @@ Classic Scale:
  Cloud native:
  - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.2.3
  - RedHat community-powered Grafana-Operator v5
- 
+
 # Version 8.0.5 (05/10/2025)
 Classic Scale:
  - Python 3.9
@@ -54,7 +82,6 @@ Classic Scale:
  Cloud native:
  - IBM Storage Scale Container Native Storage Access(CNSA) devices having minReleaseLevel 5.2.3
  - RedHat community-powered Grafana-Operator v5
-
 
 # Version 8.0.4 (04/10/2025)
 Classic Scale:

--- a/source/__version__.py
+++ b/source/__version__.py
@@ -20,4 +20,4 @@ Created on Feb 17, 2021
 @author: HWASSMAN
 '''
 
-__version__ = '9.0.0-dev'
+__version__ = '9.0.0'


### PR DESCRIPTION
The main changes of 9.0.0:
- Added example yaml files to configure Openshift ServiceMonitor for a scale cluster running outside of this Openshift cluster
- Expanded configuration parameters to allow grafana-bridge socket host to bind to ip of specific network interface
- Removed python3.9 support, set required minimum level to 3.11
- Changed the Dockerfile parent image to the registry.access.redhat.com/ubi10