### PR TITLE
Skip transfer RangeData by prometheus scrap job queries

### DIFF
--- a/source/collector.py
+++ b/source/collector.py
@@ -217,6 +217,7 @@ class QueryPolicy(object):
         '''Returns zimon query string '''
         query = Query(includeDiskData=self.md.includeDiskData)
         query.normalize_rates = False
+        query.skipRangeData = True
         query.rawData = self.rawData
 
         if not self.metricsaggr and not self.sensor:

--- a/source/queryHandler/Query.py
+++ b/source/queryHandler/Query.py
@@ -93,6 +93,7 @@ class Query(object):
         self.measurements = {}
         self.normalize_rates = True
         self.rawData = False
+        self.skipRangeData = False
         self.key = None
         self.sensor = None
 
@@ -209,15 +210,20 @@ class Query(object):
         else:
             raw = ''
 
-        if self.sensor is not None:
-            queryString = 'get -j {0} {1} group {2} bucket_size {3} {4}'.format(
-                dd, raw, self.sensor, self.bucket_size, self.timeRep)
-        elif self.key is not None:
-            queryString = 'get -j {0} {1} {2} bucket_size {3} {4}'.format(
-                dd, raw, self.key, self.bucket_size, self.timeRep)
+        if self.skipRangeData:
+            domains = '-D'
         else:
-            queryString = 'get -j {0} {1} metrics {2} bucket_size {3} {4}'.format(
-                dd, raw, ','.join(self.metrics), self.bucket_size, self.timeRep)
+            domains = ''
+
+        if self.sensor is not None:
+            queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+                dd, raw, domains, self.sensor, self.bucket_size, self.timeRep)
+        elif self.key is not None:
+            queryString = 'get -j {0} {1} {2} {3} bucket_size {4} {5}'.format(
+                dd, raw, domains, self.key, self.bucket_size, self.timeRep)
+        else:
+            queryString = 'get -j {0} {1} {2} metrics {3} bucket_size {4} {5}'.format(
+                dd, raw, domains, ','.join(self.metrics), self.bucket_size, self.timeRep)
 
         if self.filters:
             queryString += ' from ' + ",".join(self.filters)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -33,8 +33,8 @@ def test_case01():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} group {2} bucket_size {3} {4}'.format(
-            '', '-z', prometheus_attrs.get('sensor'),
+        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+            '', '-z', '-D', prometheus_attrs.get('sensor'),
             prometheus_attrs.get('period'),
             f"last {prometheus_attrs.get('period')}")
         queryString += '\n'
@@ -54,8 +54,8 @@ def test_case02():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} group {2} bucket_size {3} {4}'.format(
-            '', '', prometheus_attrs.get('sensor'),
+        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+            '', '', '-D', prometheus_attrs.get('sensor'),
             prometheus_attrs.get('period'),
             f"last {prometheus_attrs.get('nsamples')}")
         queryString += '\n'
@@ -74,8 +74,8 @@ def test_case03():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} group {2} bucket_size {3} {4}'.format(
-            '', '-z', prometheus_attrs.get('sensor'),
+        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+            '', '-z', '-D', prometheus_attrs.get('sensor'),
             prometheus_attrs.get('period'),
             f"last {prometheus_attrs.get('period')}")
         queryString += ' from ' + ",".join(pquery_filters)
@@ -97,8 +97,8 @@ def test_case04():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} group {2} bucket_size {3} {4}'.format(
-            '', '', prometheus_attrs.get('sensor'),
+        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+            '', '', '-D', prometheus_attrs.get('sensor'),
             prometheus_attrs.get('period'),
             f"last {prometheus_attrs.get('nsamples')}")
         queryString += ' from ' + ",".join(pquery_filters)


### PR DESCRIPTION
All prometheus scrap jobs pull data for the last sample interval. There is no need to transfer domain range data from pmcollector.