### PR TITLE
Add support for  --suppress-null  perfmon query option

### DIFF
--- a/source/collector.py
+++ b/source/collector.py
@@ -202,7 +202,7 @@ class SensorTimeSeries(object):
 
 @classattributes(dict(metricsaggr=None, filters=None, grouptags=None,
                       start='', end='', nsamples=0, duration=0,
-                      dsBucketSize=0, dsOp='', rawData=False, dpsArrays=False),
+                      dsBucketSize=0, dsOp='', rawData=False, skipNullValues=False, dpsArrays=False),
                  ['sensor', 'period'])
 class QueryPolicy(object):
 
@@ -219,6 +219,7 @@ class QueryPolicy(object):
         query.normalize_rates = False
         query.skipRangeData = True
         query.rawData = self.rawData
+        query.skipNullValues = self.skipNullValues
 
         if not self.metricsaggr and not self.sensor:
             raise ValueError('Missing metric or sensor name')

--- a/source/config.ini
+++ b/source/config.ini
@@ -124,7 +124,7 @@ logLevel = 15
 # Comment out this setting, if you wish to print out the trace messages directly on the command line
 logFile = zserver.log
 
-# Enable(on) or disable(off) logging of CherryPy “access” messages (one per HTTP request)
+# Enable(on) or disable(off) logging of CherryPy access messages (one per HTTP request)
 cpAccessLog = on
 
 # Number of cherrypy_access.log files to retain if cherrypy access logging is on

--- a/source/prometheus.py
+++ b/source/prometheus.py
@@ -76,6 +76,8 @@ class PrometheusExporter(object):
                                                             metric.mtype)
                         formatted_str = sts_resp.str_expfmt()
                         resp.extend(formatted_str)
+                    elif metric.mtype == "counter":
+                        self.logger.warning(f"Received null value for a counter: {name} {_key} {'|'.join(sts.tags.values())}")
         return resp
 
     @execution_time()
@@ -137,7 +139,7 @@ class PrometheusExporter(object):
         attrs = {'sensor': sensor, 'period': period}
 
         if self.raw_data or "counter" in self.TOPO.getSensorMetricTypes(sensor).values():
-            attrs.update({'nsamples': period, 'rawData': True})
+            attrs.update({'nsamples': period, 'rawData': True, 'skipNullValues': True})
             self.logger.debug(MSG['SensorForceRawData'].format(sensor))
         else:
             attrs.update({'nsamples': 1})

--- a/source/queryHandler/Query.py
+++ b/source/queryHandler/Query.py
@@ -93,6 +93,7 @@ class Query(object):
         self.measurements = {}
         self.normalize_rates = True
         self.rawData = False
+        self.skipNullValues = False
         self.skipRangeData = False
         self.key = None
         self.sensor = None
@@ -189,41 +190,41 @@ class Query(object):
         return self
 
     def __str__(self):
-        # dd = '-a' if self.includeDiskData else ''
-        # Workaround for RTC Defect 280368: Zimon capacity query does not return all results (seen on CNSA)
-        dd = ''
-        if self.includeDiskData:
-            dd = '-a'
+        queryOptions = "-j"
+
         if self.metrics:
             for metric in self.metrics:
                 if any(map(metric.__contains__, self.DISK_CAP_METRICS)):
-                    dd = '-ar'
+                    queryOptions = queryOptions + "ar"
                     break
         elif (self.sensor and self.sensor in ("GPFSDiskCap",
                                               "GPFSPoolCap",
                                               "GPFSInodeCap")
               ):
-            dd = '-ar'
+            queryOptions = queryOptions + "ar"
+        # dd = '-a' if self.includeDiskData else ''
+        # Workaround for RTC Defect 280368: Zimon capacity query does not return all results (seen on CNSA)
+        elif self.includeDiskData:
+            queryOptions = queryOptions + "a"
 
         if self.rawData:
-            raw = '-z'
-        else:
-            raw = ''
+            queryOptions = queryOptions + "z"
+
+        if self.skipNullValues:
+            queryOptions = queryOptions + "s"
 
         if self.skipRangeData:
-            domains = '-D'
-        else:
-            domains = ''
+            queryOptions = queryOptions + 'D'
 
         if self.sensor is not None:
-            queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
-                dd, raw, domains, self.sensor, self.bucket_size, self.timeRep)
+            queryString = 'get {0} group {1} bucket_size {2} {3}'.format(
+                queryOptions, self.sensor, self.bucket_size, self.timeRep)
         elif self.key is not None:
-            queryString = 'get -j {0} {1} {2} {3} bucket_size {4} {5}'.format(
-                dd, raw, domains, self.key, self.bucket_size, self.timeRep)
+            queryString = 'get {0} {1} bucket_size {2} {3}'.format(
+                queryOptions, self.key, self.bucket_size, self.timeRep)
         else:
-            queryString = 'get -j {0} {1} {2} metrics {3} bucket_size {4} {5}'.format(
-                dd, raw, domains, ','.join(self.metrics), self.bucket_size, self.timeRep)
+            queryString = 'get {0} metrics {1} bucket_size {2} {3}'.format(
+                queryOptions, ','.join(self.metrics), self.bucket_size, self.timeRep)
 
         if self.filters:
             queryString += ' from ' + ",".join(self.filters)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -5,6 +5,7 @@ from unittest import mock
 from source.bridgeLogger import configureLogging
 from source.queryHandler.Topo import Topo
 from source.collector import QueryPolicy, SensorCollector
+from source.__version__ import __version__ as version
 from nose2.tools.such import helper as assert_helper
 from nose2.tools.decorators import with_setup
 
@@ -33,10 +34,16 @@ def test_case01():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
-            '', '-z', '-D', prometheus_attrs.get('sensor'),
-            prometheus_attrs.get('period'),
-            f"last {prometheus_attrs.get('period')}")
+        if version < "9.0.3":
+            queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+                '', '-z', '-D', prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('period')}")
+        else:
+            queryString = 'get -jzD group {0} bucket_size {1} {2}'.format(
+                prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('period')}")
         queryString += '\n'
         assert "group" in query.__str__()
         assert "last" in query.__str__()
@@ -54,10 +61,16 @@ def test_case02():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
-            '', '', '-D', prometheus_attrs.get('sensor'),
-            prometheus_attrs.get('period'),
-            f"last {prometheus_attrs.get('nsamples')}")
+        if version < "9.0.3":
+            queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+                '', '', '-D', prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('nsamples')}")
+        else:
+            queryString = 'get -jD group {0} bucket_size {1} {2}'.format(
+                prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('nsamples')}")
         queryString += '\n'
         assert "group" in query.__str__()
         assert "last" in query.__str__()
@@ -74,10 +87,16 @@ def test_case03():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
-            '', '-z', '-D', prometheus_attrs.get('sensor'),
-            prometheus_attrs.get('period'),
-            f"last {prometheus_attrs.get('period')}")
+        if version < "9.0.3":
+            queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+                '', '-z', '-D', prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('period')}")
+        else:
+            queryString = 'get -jzD group {0} bucket_size {1} {2}'.format(
+                prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('period')}")
         queryString += ' from ' + ",".join(pquery_filters)
         queryString += '\n'
         assert "group" in query.__str__()
@@ -97,12 +116,20 @@ def test_case04():
         request = QueryPolicy(**prometheus_attrs)
         query = request.get_zimon_query()
         query.includeDiskData = md_instance.includeDiskData.return_value
-        queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
-            '', '', '-D', prometheus_attrs.get('sensor'),
-            prometheus_attrs.get('period'),
-            f"last {prometheus_attrs.get('nsamples')}")
+        if version < "9.0.3":
+            queryString = 'get -j {0} {1} {2} group {3} bucket_size {4} {5}'.format(
+                '', '', '-D', prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('nsamples')}")
+        else:
+            queryString = 'get -jD group {0} bucket_size {1} {2}'.format(
+                prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('nsamples')}")
         queryString += ' from ' + ",".join(pquery_filters)
         queryString += '\n'
+        print(query.__str__())
+        print(queryString)
         assert "group" in query.__str__()
         assert "last" in query.__str__()
         assert "from" in query.__str__()
@@ -110,10 +137,33 @@ def test_case04():
 
 
 @with_setup(my_setup)
+def test_case05():
+    if version > "9.0.2":
+        prometheus_attrs.update({'skipNullValues': True})
+        with mock.patch('source.collector.QueryPolicy.md') as md:
+            md_instance = md.return_value
+            md_instance.includeDiskData.return_value = False
+            md_instance.logger = logging.getLogger(__name__)
+            request = QueryPolicy(**prometheus_attrs)
+            query = request.get_zimon_query()
+            query.includeDiskData = md_instance.includeDiskData.return_value
+            queryString = 'get -jzsD group {0} bucket_size {1} {2}'.format(
+                prometheus_attrs.get('sensor'),
+                prometheus_attrs.get('period'),
+                f"last {prometheus_attrs.get('period')}")
+            queryString += '\n'
+            assert "group" in query.__str__()
+            assert "last" in query.__str__()
+            assert "from" not in query.__str__()
+            assert query.skipNullValues is True
+            assert queryString == query.__str__()
+
+
+@with_setup(my_setup)
 @mock.patch('source.collector.QueryPolicy.md')
 @mock.patch('source.collector.SensorTimeSeries.md')
 @mock.patch('source.collector.SensorCollector.md')
-def test_case05(col_md, sts_md, md):
+def test_case06(col_md, sts_md, md):
     sensor = prometheus_attrs.get('sensor')
     period = prometheus_attrs.get('period')
     logger = logging.getLogger(__name__)
@@ -143,7 +193,7 @@ def test_case05(col_md, sts_md, md):
 @mock.patch('source.collector.QueryPolicy.md')
 @mock.patch('source.collector.SensorTimeSeries.md')
 @mock.patch('source.collector.SensorCollector.md')
-def test_case06(col_md, sts_md, md):
+def test_case07(col_md, sts_md, md):
     sensor = prometheus_attrs.get('sensor')
     period = prometheus_attrs.get('period')
     logger = logging.getLogger(__name__)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -15,14 +15,15 @@ def test_case01():
     assert len(str(query)) > 0
     assert "cpu_user" in str(query)
     assert "-ar" not in str(query)
+    assert "-j" in str(query)
 
 
 @with_setup(my_setup)
 def test_case02():
     query = Query(metrics1)
-    assert "-ar" in str(query)
+    assert "-jar" in str(query)
     query.addMetric('cpu_user')
-    assert "-ar" in str(query)
+    assert "-jar" in str(query)
 
 
 @with_setup(my_setup)
@@ -30,11 +31,12 @@ def test_case03():
     for sensor in capSensors:
         query = Query()
         query.sensor = sensor
-        assert "-ar" in str(query)
+        assert "-jar" in str(query)
     query = Query()
     query.sensor = 'CPU'
-    assert "-ar" not in str(query)
+    assert "-jar" not in str(query)
+    assert "-j" in str(query)
     assert "group" in str(query)
     query = Query(includeDiskData=True)
     query.sensor = 'GPFSDiskCap'
-    assert "-ar" in str(query)
+    assert "-jar" in str(query)


### PR DESCRIPTION
In 6.0.1 new function have been introduced to perfmom query "--suppress-null" which filters out rows having only null values from the query result. This will reduce the amount of data transferred over REST HTTP Api.

PrometheusExporter should use the --suppress-null  by zimon queries if data collection configured with RawData=true