### PR TITLE
Add internal performance observability and HTTP metrics collection

### DIFF
--- a/examples/grafana_dashboards/internal_performance_observability/Prometheus scrape jobs execution comparison over time-1779302096160.json
+++ b/examples/grafana_dashboards/internal_performance_observability/Prometheus scrape jobs execution comparison over time-1779302096160.json
@@ -1,0 +1,827 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "adftpvb",
+    "generation": 31,
+    "creationTimestamp": "2026-05-19T06:26:15Z",
+    "labels": {},
+    "annotations": {}
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "spec": {},
+            "labels": {
+              "grafana.app/export-label": "grafana-1"
+            }
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "id": 10,
+          "title": "Total job execution in comparison to  $time_shift  ago",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "AA",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "AB",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"}) - avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)) / avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift) * 100",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "BB",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "CA",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "CC",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"}) - avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)) / avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift) * 100",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "DD",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "EA",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "EE",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"}) - avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)) / avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift) * 100",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{collector_name}}",
+                        "range": false
+                      }
+                    },
+                    "refId": "FF",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Time": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {},
+                      "renameByName": {}
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "sortBy",
+                  "spec": {
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "desc": true,
+                          "field": "Value #BB"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": true,
+                "frameIndex": 0,
+                "showHeader": true,
+                "sortBy": []
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percent",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 0,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 10,
+                        "color": "dark-red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false,
+                    "minWidth": 120,
+                    "wrapHeaderText": true,
+                    "wrapText": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #AA"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "total execution time"
+                      },
+                      {
+                        "id": "custom.width"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "links",
+                        "value": [
+                          {
+                            "targetBlank": true,
+                            "title": "Show historical data",
+                            "url": "/../d/ad9fs9q/d3c03d0?orgId=1&from=${__from}&to=${__to}&timezone=browser&var-Datasource=${Datasource}&var-job_name=${__data.fields.job}&var-collector_name=${__data.fields.collector_name}&var-time_shift=${time_shift}&refresh=1m"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #AB"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "execution before $time_shift"
+                      },
+                      {
+                        "id": "custom.width"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #BB"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "execution vs. $time_shift"
+                      },
+                      {
+                        "id": "custom.width"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #CA"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "perfmon response amount"
+                      },
+                      {
+                        "id": "custom.width"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #CC"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "amount before $time_shift"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #DD"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "amount vs. $time_shift"
+                      },
+                      {
+                        "id": "custom.width"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #EA"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "perfmon response duration"
+                      },
+                      {
+                        "id": "custom.width"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #EE"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "duration before $time_shift"
+                      },
+                      {
+                        "id": "custom.width"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "scope": "series",
+                      "options": "Value #FF"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "duration vs. $time_shift"
+                      },
+                      {
+                        "id": "custom.width"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "id": 11,
+          "title": "Total job execution vs. last $time_shift (%)",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"}) - avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)) / avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift) * 100",
+                        "format": "time_series",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": true,
+                        "legendFormat": "{{collector_name}} ({{job}})",
+                        "range": false,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 8,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percent",
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 0,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 10,
+                        "color": "dark-red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "links": [
+                    {
+                      "targetBlank": true,
+                      "title": "show details",
+                      "url": "/../d/ad9fs9q/d3c03d0?orgId=1&from=${__from}&to=${__to}&timezone=browser&var-Datasource=${Datasource}&var-job_name=${__field.labels.job}&var-collector_name=${__field.labels.collector_name}&var-time_shift=${time_shift}&refresh=1m"
+                    }
+                  ]
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 12,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-11"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 12,
+              "width": 24,
+              "height": 11,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-10"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-12h",
+      "to": "now",
+      "autoRefresh": "5m",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Prometheus scrape jobs execution comparison over time",
+    "variables": [
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "name": "Datasource",
+          "pluginId": "prometheus",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "allowCustomValue": false
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "job_name",
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "hide": "dontHide",
+          "refresh": "onDashboardLoad",
+          "skipUrlSync": false,
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "datasource": {
+              "name": "${Datasource}"
+            },
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(PrometheusExporter_metrics,job)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "disabled",
+          "definition": "label_values(PrometheusExporter_metrics,job)",
+          "options": [],
+          "multi": true,
+          "includeAll": true,
+          "allowCustomValue": false
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "collector_name",
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "hide": "dontHide",
+          "refresh": "onTimeRangeChanged",
+          "skipUrlSync": false,
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "datasource": {
+              "name": "${Datasource}"
+            },
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(PrometheusExporter_metrics{job=~\"$job_name\"},collector_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "disabled",
+          "definition": "label_values(PrometheusExporter_metrics{job=~\"$job_name\"},collector_name)",
+          "options": [],
+          "multi": true,
+          "includeAll": true,
+          "allowCustomValue": false
+        }
+      },
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "name": "time_shift",
+          "query": "1h, 3h, 6h, 12h, 1d, 7d",
+          "current": {
+            "text": "1d",
+            "value": "1d"
+          },
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "label": "Timeshift",
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "allowCustomValue": false,
+          "valuesFormat": "csv"
+        }
+      }
+    ]
+  }
+}

--- a/examples/grafana_dashboards/internal_performance_observability/Single Prometheusscrape job execution comparison over time-1779302278182.json
+++ b/examples/grafana_dashboards/internal_performance_observability/Single Prometheusscrape job execution comparison over time-1779302278182.json
@@ -1,0 +1,909 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ad9fs9q",
+    "generation": 41,
+    "creationTimestamp": "2026-05-16T17:36:03Z",
+    "labels": {},
+    "annotations": {}
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "spec": {},
+            "labels": {
+              "grafana.app/export-label": "grafana-1"
+            }
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Perfmon query response",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{collector_name}} - actual",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{collector_name}} - before $time_shift",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Total job duration for scraping $collector_name",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{collector_name}} - actual",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{collector_name}} - before $time_shift",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "id": 6,
+          "title": "Received bytes from Perfmon",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{collector_name}} -actual",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{collector_name}} -before $time_shift",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 7,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "id": 8,
+          "title": "Total job execution vs. last $time_shift (%)",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "(avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"}) - avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)) / avg by (collector_name,job)(PrometheusExporter_metrics{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift) * 100",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{collector_name}} ",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percent",
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 0,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 10,
+                        "color": "dark-red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-9": {
+        "kind": "Panel",
+        "spec": {
+          "id": 9,
+          "title": "Perfmon data/time vs. last $time_shift (%)",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "(avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"}) - avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)) / avg by (collector_name,job)(perfmon_response_amount{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift) * 100",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "received bytes (%)",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "(avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"}) - avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift)) / avg by (collector_name,job)(perfmon_response_duration{collector_name=~\"$collector_name\", job=~\"$job_name\"} offset $time_shift) * 100",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "response duration (%)",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "vertical",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percent",
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 0,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 10,
+                        "color": "dark-red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 18,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 18,
+              "y": 0,
+              "width": 6,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-8"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 8,
+              "width": 8,
+              "height": 7,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 8,
+              "y": 8,
+              "width": 10,
+              "height": 7,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 18,
+              "y": 8,
+              "width": 6,
+              "height": 7,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-9"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-12h",
+      "to": "now",
+      "autoRefresh": "5m",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Single Prometheus scrape job execution comparison over time",
+    "variables": [
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "name": "Datasource",
+          "pluginId": "prometheus",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "allowCustomValue": true
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "job_name",
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "hide": "dontHide",
+          "refresh": "onDashboardLoad",
+          "skipUrlSync": false,
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "datasource": {
+              "name": "${Datasource}"
+            },
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(PrometheusExporter_metrics,job)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "disabled",
+          "definition": "label_values(PrometheusExporter_metrics,job)",
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "allowCustomValue": false
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "collector_name",
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "hide": "dontHide",
+          "refresh": "onTimeRangeChanged",
+          "skipUrlSync": false,
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "datasource": {
+              "name": "${Datasource}"
+            },
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(PrometheusExporter_metrics{job=~\"$job_name\"},collector_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "disabled",
+          "definition": "label_values(PrometheusExporter_metrics{job=~\"$job_name\"},collector_name)",
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "allowCustomValue": false
+        }
+      },
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "name": "time_shift",
+          "query": "1h, 3h, 6h, 12h, 1d, 7d",
+          "current": {
+            "text": "1d",
+            "value": "1d"
+          },
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "label": "Timeshift",
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "allowCustomValue": false,
+          "valuesFormat": "csv"
+        }
+      }
+    ]
+  }
+}

--- a/source/analytics.py
+++ b/source/analytics.py
@@ -20,11 +20,16 @@ Created on Feb 09, 2024
 @author: HWASSMAN
 '''
 
-global inspect
-inspect = False
+# Enable or disable HTTP metrics collection for internal execution time tracking
+# When enabled, execution time metrics are stored in internal_metrics
+# When disabled, execution times are only logged
+global http_metrics_enabled
+http_metrics_enabled = False
 
+# Detail level for special inspection (0=disabled, 1-5=increasing detail)
+# Higher values enable more detailed tracing
 global inspect_special
-inspect_special = False
+inspect_special = 0
 
 global urllib3_debug
 urllib3_debug = 0

--- a/source/collector.py
+++ b/source/collector.py
@@ -26,7 +26,7 @@ import analytics
 from queryHandler.Query import Query
 from messages import MSG
 from collections import defaultdict
-from typing import Optional, Any, List
+from typing import Optional, Any, List, Union
 from threading import Thread
 from metadata import MetadataHandler
 from bridgeLogger import getBridgeLogger

--- a/source/collector.py
+++ b/source/collector.py
@@ -48,7 +48,7 @@ class TimeSeries(object):
 
         self.parse_tags(filtersMap, defaultLabels)
 
-    @cond_execution_time(enabled=analytics.inspect_special)
+    @cond_execution_time(detail_level=2)
     def parse_tags(self, filtersMap, defaultLabels):
         logger = getBridgeLogger()
         if not (filtersMap and defaultLabels):
@@ -146,6 +146,7 @@ class SensorTimeSeries(object):
         self.sensor = sensor
         self.period = period
         self.metrics = {}
+        self.internal_metrics: defaultdict[int, dict[str, Union[int, float]]] = defaultdict(dict)
         self.filtersMap = self._get_all_filters()
         self.labels = self._get_sensor_labels()
 
@@ -267,12 +268,14 @@ class SensorCollector(SensorTimeSeries):
     thread = None
 
     def __init__(self, sensor: str, period: str, logger, request: QueryPolicy,
+                 bundle_id: Optional[str] = None,
                  *args: Any, **kwargs: Any) -> None:
         super().__init__(sensor, period)
         self.__query = None
         self.__ds_interval = None
         self.request = request
         self.logger = logger
+        self.bundle_id = bundle_id  # Store bundle_id as instance property
         self.removeNoData = False
         self.cache = False
         self.cached_metrics = {}
@@ -302,13 +305,11 @@ class SensorCollector(SensorTimeSeries):
         """ Function to start collect in a thread"""
         self.running = True
         if not self.thread:
-            thread_name = list(
-                self.request.metricsaggr.keys())[0] +\
-                '_Collector' if self.request.metricsaggr else self.sensor +\
-                '_Collector'
+            thread_name = list(self.request.metricsaggr.keys())[0] if self.request.metricsaggr else self.sensor
             self.thread = Thread(name=thread_name, target=self.collect)
             self.thread.start()
-            self.thread.name += '_' + str(self.thread.ident)
+            # self.thread.name += '_' + str(self.thread.ident)
+            # self.logger.info(f"Started col thread with ident {self.thread.ident}")
             self.logger.trace(
                 MSG['StartCustomThread'].format(self.thread.name))
 
@@ -397,13 +398,13 @@ class SensorCollector(SensorTimeSeries):
                 self.metrics[columnInfo.keys[0].metric] = mt
         # self.logger.info(f'rows data {str(columnValues)}')
 
-    @cond_execution_time(enabled=analytics.inspect_special)
+    @cond_execution_time(detail_level=2)
     def prepare_static_metrics_data(self):
         incl_metrics = list(self.request.metricsaggr.keys()
                             ) if self.request.metricsaggr else None
         self.setup_static_metrics_data(incl_metrics)
 
-    @cond_execution_time(enabled=analytics.inspect_special)
+    @cond_execution_time(detail_level=2)
     def validate_query_filters(self):
         # check filterBy settings
         if self.request.filters:
@@ -452,7 +453,7 @@ class SensorCollector(SensorTimeSeries):
                 raise cherrypy.HTTPError(
                     400, MSG['AttrNotValid'].format('filter'))
 
-    @cond_execution_time(enabled=analytics.inspect_special)
+    @cond_execution_time(detail_level=2)
     def validate_group_tags(self):
         # check groupBy settings
         if self.request.grouptags:

--- a/source/messages.py
+++ b/source/messages.py
@@ -90,6 +90,12 @@ MSG = {'IntError': 'Server internal error occurred. Reason: {}',
        'ConnApplications': 'Registered applications: \n {}',
        'WrongFormat': 'The {} specified in wrong format.',
        'AuthValidationError': 'Basic authentication data not valid',
+       'BundleIdTrackingDisabled': 'Bundle ID tracking is disabled. Enable http_metrics_enabled in analytics.py',
+       'HttpMetricsRecordFailed': 'Failed to record HTTP metrics: {}',
+       'CollectorThreadTrace': 'Collector thread statistics:\n%s\nCollector thread labels:\n%s\nCollector thread bundle_id:\n%s',
+       'InternalExecutionMetricsCacheFailed': 'Failed to cache internal execution time metrics: {}',
+       'BundleIdGenerated': '{} bundle_id: {}',
+       'BundleIdNotFound': 'Bundle ID not found in registry',
        'RestApiInfo': 'Use http(s)://<grafana-bridge ip>:<app port>/endpoints with optional flags \n\t \
 -u <credentials> for basic authentication and \n\t \
 -k to bypass certificate verification,\n \

--- a/source/opentsdb.py
+++ b/source/opentsdb.py
@@ -45,6 +45,7 @@ _opentsdb_bundle_registry: OrderedDict[str, Dict[str, Any]] = OrderedDict()
 _registry_lock = Lock()
 _MAX_REGISTRY_SIZE = 100  # Keep last 100 bundle_ids for debugging
 
+
 def _normalize_query(query: dict) -> dict:
     """Extract and normalize query parameters for consistent hashing."""
     return {
@@ -76,7 +77,6 @@ def _generate_bundle_id_from_tuple(queries_tuple: Tuple[str, ...], host: str) ->
     Args:
         queries_tuple: Tuple of JSON-serialized query strings
         host: Request host (without port)
-        
     Returns:
         16-character hexadecimal bundle identifier
     """
@@ -129,7 +129,6 @@ def _register_bundle_id(bundle_id: str, queries: List[dict], host: str, jreq: di
     """
     Register a bundle_id with its query information for debugging/logging.
     Maintains a size-limited registry using LRU eviction.
-    
     Args:
         bundle_id: The generated bundle identifier
         queries: List of query dictionaries
@@ -194,7 +193,6 @@ def clear_bundle_registry():
 def get_bundle_registry_stats() -> Dict[str, Any]:
     """
     Get statistics about the bundle ID registry.
-    
     Returns:
         Dictionary with registry statistics
     """

--- a/source/opentsdb.py
+++ b/source/opentsdb.py
@@ -22,14 +22,193 @@ Created on Oct 24, 2023
 
 import cherrypy
 import re
+import json
+import sys
 import analytics
+from functools import lru_cache
 from messages import ERR, MSG
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
+from threading import Lock
 from collector import SensorCollector, QueryPolicy
-from utils import getTimeMultiplier, execution_time, cond_execution_time
-from typing import List, TypeVar
+from utils import getTimeMultiplier, execution_time, cond_execution_time, get_request_host
+from typing import List, TypeVar, Tuple, Optional, Union, Dict, Any
 
 T = TypeVar('T', dict, list)
+
+
+# ============================================================================
+# Bundle ID Generation with Caching and Registry
+# ============================================================================
+
+# Bundle ID registry for debugging/logging (limited size, thread-safe)
+_opentsdb_bundle_registry: OrderedDict[str, Dict[str, Any]] = OrderedDict()
+_registry_lock = Lock()
+_MAX_REGISTRY_SIZE = 100  # Keep last 100 bundle_ids for debugging
+
+def _normalize_query(query: dict) -> dict:
+    """Extract and normalize query parameters for consistent hashing."""
+    return {
+        'metric': query.get('metric'),
+        'aggregator': query.get('aggregator'),
+        'tags': query.get('tags', {}),
+        'filters': query.get('filters', []),
+        'downsample': query.get('downsample'),
+        'explicitTags': query.get('explicitTags', False),
+        'isCounter': query.get('isCounter', False),
+        'datasource_uid': query.get('datasource', {}).get('uid') if isinstance(query.get('datasource'), dict) else None
+    }
+
+
+def _queries_to_hashable(queries: List[dict]) -> Tuple[str, ...]:
+    """Convert list of queries to a hashable tuple for caching."""
+    normalized = []
+    for q in queries:
+        norm_query = _normalize_query(q)
+        query_str = json.dumps(norm_query, sort_keys=True)
+        normalized.append(query_str)
+    return tuple(sorted(normalized))
+
+
+@lru_cache(maxsize=1000)
+def _generate_bundle_id_from_tuple(queries_tuple: Tuple[str, ...], host: str) -> str:
+    """
+    Cached function that generates bundle_id using Python's built-in hash.
+    Args:
+        queries_tuple: Tuple of JSON-serialized query strings
+        host: Request host (without port)
+        
+    Returns:
+        16-character hexadecimal bundle identifier
+    """
+    # Combine queries tuple and host for hashing
+    combined = (queries_tuple, host)
+    hash_value = hash(combined)
+    return f"{abs(hash_value):016x}"
+
+
+def generate_query_bundle_id_cached(jreq: dict) -> str:
+    """
+    Generate a deterministic, cached identifier for a bundle of queries.
+    Includes host and datasource UID in the hash.
+    Also stores the mapping in a registry for debugging/logging purposes.
+    Args:
+        jreq: Request dictionary containing 'queries' list
+    Returns:
+        16-character hexadecimal bundle identifier
+    """
+    queries = jreq.get('queries', [])
+    if not queries:
+        return '0000000000000000'
+
+    # Get host from request headers
+    host = get_request_host()
+
+    # Convert queries to hashable tuple (includes datasource.uid)
+    queries_tuple = _queries_to_hashable(queries)
+
+    # Generate bundle ID with host included
+    bundle_id = _generate_bundle_id_from_tuple(queries_tuple, host)
+
+    # Store in registry for debugging (thread-safe, size-limited)
+    _register_bundle_id(bundle_id, queries, host, jreq)
+
+    return bundle_id
+
+
+def get_bundle_id_cache_info():
+    """Get cache statistics for monitoring."""
+    return _generate_bundle_id_from_tuple.cache_info()
+
+
+def clear_bundle_id_cache():
+    """Clear the bundle ID cache."""
+    _generate_bundle_id_from_tuple.cache_clear()
+
+
+def _register_bundle_id(bundle_id: str, queries: List[dict], host: str, jreq: dict) -> None:
+    """
+    Register a bundle_id with its query information for debugging/logging.
+    Maintains a size-limited registry using LRU eviction.
+    
+    Args:
+        bundle_id: The generated bundle identifier
+        queries: List of query dictionaries
+        host: Request host
+        jreq: Full request dictionary used to extract start and end values
+    """
+    with _registry_lock:
+        # If bundle_id already exists, move it to end (most recent)
+        if bundle_id in _opentsdb_bundle_registry:
+            _opentsdb_bundle_registry.move_to_end(bundle_id)
+        else:
+            # Add new entry
+            _opentsdb_bundle_registry[bundle_id] = {
+                'queries': queries,
+                'host': host,
+                'start': jreq.get('start'),
+                'end': jreq.get('end')
+            }
+
+            # Evict oldest entry if size limit exceeded
+            if len(_opentsdb_bundle_registry) > _MAX_REGISTRY_SIZE:
+                _opentsdb_bundle_registry.popitem(last=False)
+
+
+def get_bundle_info(bundle_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Retrieve query information for a given bundle_id (for debugging/logging).
+    Args:
+        bundle_id: The bundle identifier to look up
+    Returns:
+        Dictionary containing query information, or None if not found
+    Example:
+        >>> info = get_bundle_info('a3f5c8d9e2b1f4a7')
+        >>> if info:
+        ...     print(f"Host: {info['host']}")
+        ...     print(f"Queries: {info['queries']}")
+    """
+    with _registry_lock:
+        return _opentsdb_bundle_registry.get(bundle_id)
+
+
+def get_all_bundle_ids() -> Dict[str, Dict[str, Any]]:
+    """
+    Get all registered bundle_ids with their query information (for debugging).
+    Returns:
+        Dictionary mapping bundle_ids to their query information
+    Example:
+        >>> all_bundles = get_all_bundle_ids()
+        >>> for bundle_id, info in all_bundles.items():
+        ...     print(f"{bundle_id}: {len(info['queries'])} queries")
+    """
+    with _registry_lock:
+        return dict(_opentsdb_bundle_registry)
+
+
+def clear_bundle_registry():
+    """Clear the bundle ID registry (for debugging/testing)."""
+    with _registry_lock:
+        _opentsdb_bundle_registry.clear()
+
+
+def get_bundle_registry_stats() -> Dict[str, Any]:
+    """
+    Get statistics about the bundle ID registry.
+    
+    Returns:
+        Dictionary with registry statistics
+    """
+    with _registry_lock:
+        memory_size = sys.getsizeof(_opentsdb_bundle_registry) + sum(
+            sys.getsizeof(bundle_id) + sys.getsizeof(bundle_info)
+            for bundle_id, bundle_info in _opentsdb_bundle_registry.items()
+        )
+        return {
+            'size': len(_opentsdb_bundle_registry),
+            'max_size': _MAX_REGISTRY_SIZE,
+            'memory_size': memory_size,
+            'bundle_ids': list(_opentsdb_bundle_registry.keys())
+        }
 
 
 class OpenTsdbApi(object):
@@ -39,6 +218,7 @@ class OpenTsdbApi(object):
         self.logger = logger
         self.__md = mdHandler
         self.port = port
+        self.internal_metrics: defaultdict[int, dict[str, Union[int, float]]] = defaultdict(dict)
 
     @property
     def md(self):
@@ -52,7 +232,7 @@ class OpenTsdbApi(object):
     def TOPO(self):
         return self.__md.metaData
 
-    @cond_execution_time(enabled=analytics.inspect_special)
+    @cond_execution_time(detail_level=1)
     def format_response(self, data: dict, jreq: dict) -> List[dict]:
         respList = []
         metrics = set(data.values())
@@ -82,7 +262,11 @@ class OpenTsdbApi(object):
         return respList
 
     @execution_time()
-    def query(self, jreq: dict) -> List[dict]:
+    def query(self, jreq: dict, bundle_id: Optional[str] = None) -> List[dict]:
+
+        import threading
+        current = threading.current_thread()
+
         resp = []
         collectors = []
 
@@ -105,6 +289,7 @@ class OpenTsdbApi(object):
             request_data = jreq.copy()
             request_data.pop('queries')
             request_data['inputQuery'] = q
+            request_data['bundle_id'] = bundle_id
 
             collector = self.build_collector(request_data)
             collectors.append((collector, request_data))
@@ -121,15 +306,53 @@ class OpenTsdbApi(object):
             self.logger.trace('Finished custom thread %r.' % collector.thread.name)
 
             coll_resp = self.format_response(collector.metrics, request_data)
+            if analytics.http_metrics_enabled:
+                try:
+                    from stats import get_metrics_collector
+
+                    # Get metrics from query handler
+                    metrics = collector.md.qh.internal_metrics.pop(collector.thread.ident)
+
+                    # Collect metrics from both thread identifiers efficiently
+                    keys_to_remove = [collector.thread.ident, current.ident]
+                    col_metrics = {}
+                    for key in keys_to_remove:
+                        if key in collector.internal_metrics:
+                            col_metrics.update(collector.internal_metrics.pop(key))
+
+                    # Merge all metrics
+                    metrics.update(col_metrics)
+
+                    # Build labels dict
+                    labels = {
+                        "bundle_id": bundle_id,
+                        "collector_name": collector.thread.name
+                    }
+
+                    if collector.request.filters:
+                        labels.update(collector.request.filters)
+
+                    self.logger.trace(
+                        MSG['CollectorThreadTrace'],
+                        metrics,
+                        labels,
+                        bundle_id,
+                    )
+
+                    stats_collector = get_metrics_collector()
+                    stats_collector.record_metric(labels=labels, metrics=metrics)
+                except Exception as exc:
+                    self.logger.debug(MSG['HttpMetricsRecordFailed'].format(exc))
             # cherrypy.response.headers['Access-Control-Allow-Origin'] = '*'
             resp.extend(coll_resp)
         cherrypy.response.headers['Access-Control-Allow-Origin'] = '*'
         return resp
 
-    @cond_execution_time(enabled=analytics.inspect)
+    @cond_execution_time(detail_level=1)
     def build_collector(self, jreq: dict) -> SensorCollector:
 
         q = jreq.get('inputQuery')
+        bundle_id = jreq.get('bundle_id', None)
 
         sensor = self.TOPO.getSensorForMetric(q.get('metric'))
         period = self.md.getSensorPeriod(sensor)
@@ -171,7 +394,7 @@ class OpenTsdbApi(object):
         request = QueryPolicy(**args)
         self.logger.trace(f'request instance {str(request.__dict__)}')
 
-        collector = SensorCollector(sensor, period, self.logger, request)
+        collector = SensorCollector(sensor, period, self.logger, request, bundle_id=bundle_id)
         self.logger.trace(f'Collector instance {str(collector.__dict__)}')
 
         collector.validate_query_filters()
@@ -354,7 +577,44 @@ class OpenTsdbApi(object):
             jreq['start'] = 'last'
             jreq['queries'] = queries
 
-            resp = self.query(jreq)
+            # Generate bundle_id only if metrics are enabled
+            bundle_id = None
+            if analytics.http_metrics_enabled:
+                bundle_id = generate_query_bundle_id_cached(jreq)
+                self.logger.trace(MSG['BundleIdGenerated'].format(cherrypy.request.script_name, bundle_id))
+
+            resp = self.query(jreq, bundle_id=bundle_id)
+
+        # /api/bundle_ids - List all registered bundle IDs (only if http_metrics_enabled)
+        elif '/api/bundle_ids' == cherrypy.request.script_name:
+            if not analytics.http_metrics_enabled:
+                self.logger.error('Bundle ID endpoint requires http_metrics_enabled=True')
+                raise cherrypy.HTTPError(503, MSG['BundleIdTrackingDisabled'])
+            if params.get('bundle_id'):
+                # Get specific bundle ID info
+                bundle_id = params.get('bundle_id')
+                info = get_bundle_info(bundle_id)
+                if info:
+                    resp = {
+                        'bundle_id': bundle_id,
+                        'found': True,
+                        'info': info
+                    }
+                else:
+                    resp = {
+                        'bundle_id': bundle_id,
+                        'found': False,
+                        'message': 'Bundle ID not found in registry'
+                    }
+            else:
+                # List all bundle IDs with stats
+                all_bundles = get_all_bundle_ids()
+                stats = get_bundle_registry_stats()
+                resp = {
+                    'registry_type': 'opentsdb',
+                    'stats': stats,
+                    'bundles': all_bundles
+                }
 
         elif 'aggregators' in cherrypy.request.script_name:
             resp = ["noop", "sum", "avg", "max", "min", "rate"]
@@ -407,7 +667,35 @@ class OpenTsdbApi(object):
             if params and params.get('arrays') == 'true':
                 jreq['arrays'] = True
 
-            return self.query(jreq)
+            # Generate bundle_id only if metrics are enabled
+            bundle_id = None
+            if analytics.http_metrics_enabled:
+                bundle_id = generate_query_bundle_id_cached(jreq)
+                self.logger.trace(MSG['BundleIdGenerated'].format(cherrypy.request.script_name, bundle_id))
+
+            resp = self.query(jreq, bundle_id=bundle_id)
+
+            if analytics.http_metrics_enabled:
+                try:
+                    import threading
+                    current = threading.current_thread()
+                    if current.ident in self.internal_metrics:
+                        metrics = self.internal_metrics.pop(current.ident)
+                        metric_name = jreq['queries'][0].get('metric') if len(jreq['queries']) == 1 else "multiple_metrics"
+
+                        # Build labels dict in one operation instead of multiple updates
+                        labels = {
+                            "bundle_id": bundle_id,
+                            "collector_name": metric_name,
+                            **params  # Unpack params directly
+                        }
+
+                        from stats import get_metrics_collector
+                        stats_collector = get_metrics_collector()
+                        stats_collector.record_metric(labels=labels, metrics=metrics)
+                except Exception as exc:
+                    self.logger.debug(MSG['HttpMetricsRecordFailed'].format(exc))
+            return resp
 
     def OPTIONS(self):
         # print('options_post')

--- a/source/prometheus.py
+++ b/source/prometheus.py
@@ -21,13 +21,180 @@ Created on Oct 30, 2023
 '''
 
 import cherrypy
+import copy
 import json
+import sys
 import analytics
+from functools import lru_cache
 from messages import ERR, MSG
-from typing import Optional
+from typing import Optional, Union, List, Tuple, Dict, Any
+from collections import OrderedDict, defaultdict
+from threading import Lock
 from cherrypy.process.plugins import Monitor
 from collector import SensorCollector, QueryPolicy
-from utils import execution_time, cond_execution_time
+from utils import execution_time, cond_execution_time, get_request_host
+
+
+# ============================================================================
+# Bundle ID Generation with Caching and Registry (for Prometheus)
+# ============================================================================
+
+# Bundle ID registry for debugging/logging (limited size, thread-safe)
+_prometheus_bundle_registry: OrderedDict[str, Dict[str, Any]] = OrderedDict()
+_prometheus_registry_lock = Lock()
+_PROMETHEUS_MAX_REGISTRY_SIZE = 100  # Keep last 100 bundle_ids for debugging
+
+def _normalize_prometheus_request(sensors: list, filters: Optional[dict] = None) -> dict:
+    """Extract and normalize Prometheus request parameters for consistent hashing."""
+    return {
+        'sensors': sorted(sensors) if sensors else [],
+        'filters': filters if filters else {}
+    }
+
+
+def _prometheus_request_to_hashable(sensors: list, filters: Optional[dict] = None) -> str:
+    """Convert Prometheus request to a hashable string for caching."""
+    norm_request = _normalize_prometheus_request(sensors, filters)
+    return json.dumps(norm_request, sort_keys=True)
+
+
+@lru_cache(maxsize=1000)
+def _generate_prometheus_bundle_id_from_tuple(request_str: str, host: str) -> str:
+    """
+    Cached function that generates bundle_id using Python's built-in hash.
+    Args:
+        request_str: JSON-serialized request string
+        host: Request host (without port)
+    Returns:
+        16-character hexadecimal bundle identifier
+    """
+    # Combine request and host for hashing
+    combined = (request_str, host)
+    hash_value = hash(combined)
+    return f"{abs(hash_value):016x}"
+
+
+def generate_prometheus_bundle_id_cached(sensors: list, filters: Optional[dict] = None) -> str:
+    """
+    Generate a deterministic, cached identifier for a Prometheus request.
+    Includes host and sensor/filter information in the hash.
+    Also stores the mapping in a registry for debugging/logging purposes.
+    Args:
+        sensors: List of sensor names
+        filters: Optional dictionary of filters
+    Returns:
+        16-character hexadecimal bundle identifier
+    """
+    if not sensors:
+        return '0000000000000000'
+
+    # Get host from request headers
+    host = get_request_host()
+
+    # Convert request to hashable string
+    request_str = _prometheus_request_to_hashable(sensors, filters)
+
+    # Generate bundle ID with host included
+    bundle_id = _generate_prometheus_bundle_id_from_tuple(request_str, host)
+
+    # Store in registry for debugging (thread-safe, size-limited)
+    _register_prometheus_bundle_id(bundle_id, sensors, filters, host)
+
+    return bundle_id
+
+
+def get_prometheus_bundle_id_cache_info():
+    """Get cache statistics for monitoring."""
+    return _generate_prometheus_bundle_id_from_tuple.cache_info()
+
+
+def clear_prometheus_bundle_id_cache():
+    """Clear the bundle ID cache."""
+    _generate_prometheus_bundle_id_from_tuple.cache_clear()
+
+
+def _register_prometheus_bundle_id(bundle_id: str, sensors: list, filters: Optional[dict], host: str) -> None:
+    """
+    Register a Prometheus bundle_id with its request information for debugging/logging.
+    Maintains a size-limited registry using LRU eviction.
+    Args:
+        bundle_id: The generated bundle identifier
+        sensors: List of sensor names
+        filters: Optional dictionary of filters
+        host: Request host
+    """
+    with _prometheus_registry_lock:
+        # If bundle_id already exists, move it to end (most recent)
+        if bundle_id in _prometheus_bundle_registry:
+            _prometheus_bundle_registry.move_to_end(bundle_id)
+        else:
+            # Add new entry
+            _prometheus_bundle_registry[bundle_id] = {
+                'sensors': sensors,
+                'filters': filters if filters else {},
+                'host': host
+            }
+
+            # Evict oldest entry if size limit exceeded
+            if len(_prometheus_bundle_registry) > _PROMETHEUS_MAX_REGISTRY_SIZE:
+                _prometheus_bundle_registry.popitem(last=False)
+
+
+def get_prometheus_bundle_info(bundle_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Retrieve request information for a given Prometheus bundle_id (for debugging/logging).
+    Args:
+        bundle_id: The bundle identifier to look up
+    Returns:
+        Dictionary containing request information, or None if not found
+    Example:
+        >>> info = get_prometheus_bundle_info('x9y8z7w6v5u4t3s2')
+        >>> if info:
+        ...     print(f"Host: {info['host']}")
+        ...     print(f"Sensors: {info['sensors']}")
+        ...     print(f"Filters: {info['filters']}")
+    """
+    with _prometheus_registry_lock:
+        return _prometheus_bundle_registry.get(bundle_id)
+
+
+def get_all_prometheus_bundle_ids() -> Dict[str, Dict[str, Any]]:
+    """
+    Get all registered Prometheus bundle_ids with their request information (for debugging).
+    Returns:
+        Dictionary mapping bundle_ids to their request information
+    Example:
+        >>> all_bundles = get_all_prometheus_bundle_ids()
+        >>> for bundle_id, info in all_bundles.items():
+        ...     print(f"{bundle_id}: {len(info['sensors'])} sensors")
+    """
+    with _prometheus_registry_lock:
+        return dict(_prometheus_bundle_registry)
+
+
+def clear_prometheus_bundle_registry():
+    """Clear the Prometheus bundle ID registry (for debugging/testing)."""
+    with _prometheus_registry_lock:
+        _prometheus_bundle_registry.clear()
+
+
+def get_prometheus_bundle_registry_stats() -> Dict[str, Any]:
+    """
+    Get statistics about the Prometheus bundle ID registry.
+    Returns:
+        Dictionary with registry statistics
+    """
+    with _prometheus_registry_lock:
+        memory_size = sys.getsizeof(_prometheus_bundle_registry) + sum(
+            sys.getsizeof(bundle_id) + sys.getsizeof(bundle_info)
+            for bundle_id, bundle_info in _prometheus_bundle_registry.items()
+        )
+        return {
+            'size': len(_prometheus_bundle_registry),
+            'max_size': _PROMETHEUS_MAX_REGISTRY_SIZE,
+            'memory_size': memory_size,
+            'bundle_ids': list(_prometheus_bundle_registry.keys())
+        }
 
 
 class PrometheusExporter(object):
@@ -42,6 +209,7 @@ class PrometheusExporter(object):
         self.cache_strategy = False
         self.endpoints = {}
         self.caching_collectors = []
+        self.internal_metrics: defaultdict[int, dict[str, Union[int, float]]] = defaultdict(dict)
         if self.cache_strategy:
             self.initialize_cache_collectors()
 
@@ -57,7 +225,7 @@ class PrometheusExporter(object):
     def TOPO(self):
         return self.__md.metaData
 
-    @cond_execution_time(enabled=analytics.inspect_special)
+    @cond_execution_time(detail_level=1)
     def format_response(self, data) -> [str]:
         resp = []
         for name, metric in data.items():
@@ -81,7 +249,7 @@ class PrometheusExporter(object):
         return resp
 
     @execution_time()
-    def metrics(self, export_sensors: Optional[list] = None, filters: Optional[dict] = None):
+    def metrics(self, export_sensors: Optional[list] = None, filters: Optional[dict] = None, bundle_id: Optional[str] = None):
         export_sensors = export_sensors or []
         resp = []
 
@@ -90,18 +258,21 @@ class PrometheusExporter(object):
                 respList = self.format_response(collector.cached_metrics)
                 resp.extend(respList)
         elif len(export_sensors) > 0:
-            resp = self._metrics(export_sensors, filters)
+            resp = self._metrics(export_sensors, filters, bundle_id)
         else:
-            resp = self._metrics(self.static_sensors_list)
+            resp = self._metrics(self.static_sensors_list, None, bundle_id)
 
         return resp
 
-    def _metrics(self, export_sensors: list, filters: Optional[dict] = None):
+    def _metrics(self, export_sensors: list, filters: Optional[dict] = None, bundle_id: Optional[str] = None):
         resp = []
         collectors = []
 
+        import threading
+        current = threading.current_thread()
+
         for sensor in export_sensors:
-            collector = self.build_collector(sensor, filters)
+            collector = self.build_collector(sensor, filters, bundle_id=bundle_id)
             collectors.append(collector)
 
         for collector in collectors:
@@ -115,6 +286,39 @@ class PrometheusExporter(object):
             respList = self.format_response(collector.metrics)
             if len(respList) <= len(collector.metrics) * 2:
                 self.logger.warning(MSG['AllDpsNullForSensor'].format(collector.sensor))
+            if analytics.http_metrics_enabled:
+                try:
+                    from stats import get_metrics_collector
+
+                    # Get metrics from query handler
+                    metrics = collector.md.qh.internal_metrics.pop(collector.thread.ident)
+                    # Collect metrics from both thread identifiers efficiently
+                    keys_to_remove = [collector.thread.ident, current.ident]
+                    col_metrics = {}
+                    for key in keys_to_remove:
+                        if key in collector.internal_metrics:
+                            col_metrics.update(collector.internal_metrics.pop(key))
+                    # Merge all metrics
+                    metrics.update(col_metrics)
+                    # Build labels dict in one operation instead of multiple updates
+                    labels = {
+                        "bundle_id": bundle_id,
+                        "collector_name": collector.sensor
+                    }
+                    # Add filters if provided
+                    if filters:
+                        labels.update(filters)
+                    self.logger.trace(
+                        MSG['CollectorThreadTrace'],
+                        metrics,
+                        labels,
+                        bundle_id,
+                    )
+                    # Record metrics
+                    stats_collector = get_metrics_collector()
+                    stats_collector.record_metric(labels=labels, metrics=metrics)
+                except Exception as exc:
+                    self.logger.debug(MSG['HttpMetricsRecordFailed'].format(exc))
             resp.extend(respList)
         return resp
 
@@ -128,8 +332,8 @@ class PrometheusExporter(object):
                     frequency=collector.period,
                     name=thread_name).subscribe()
 
-    @cond_execution_time(enabled=analytics.inspect)
-    def build_collector(self, sensor: str, filters: Optional[dict] = None) -> SensorCollector:
+    @cond_execution_time(detail_level=1)
+    def build_collector(self, sensor: str, filters: Optional[dict] = None, bundle_id: Optional[str] = None) -> SensorCollector:
 
         period = self.md.getSensorPeriod(sensor)
         if period < 1:
@@ -151,7 +355,7 @@ class PrometheusExporter(object):
             attrs['filters'] = filters
 
         request = QueryPolicy(**attrs)
-        collector = SensorCollector(sensor, period, self.logger, request)
+        collector = SensorCollector(sensor, period, self.logger, request, bundle_id=bundle_id)
         collector.validate_query_filters()
 
         # self.logger.trace(f'request instance {str(request.__dict__)}')
@@ -175,9 +379,33 @@ class PrometheusExporter(object):
         if self.endpoints and self.endpoints.get(cherrypy.request.script_name,
                                                  None):
             sensor = self.endpoints[cherrypy.request.script_name]
-            resp = self.metrics([sensor], params)
+
+            # Generate bundle_id only if http metrics are enabled
+            bundle_id = None
+            if analytics.http_metrics_enabled:
+                bundle_id = generate_prometheus_bundle_id_cached([sensor], params)
+                self.logger.trace(MSG['BundleIdGenerated'].format(cherrypy.request.script_name, bundle_id))
+
+            resp = self.metrics([sensor], params, bundle_id=bundle_id)
             cherrypy.response.headers['Content-Type'] = 'text/plain'
             resString = '\n'.join(resp) + '\n'
+            if analytics.http_metrics_enabled:
+                try:
+                    from stats import get_metrics_collector
+                    import threading
+                    current = threading.current_thread()
+                    if current.ident in self.internal_metrics:
+                        metrics = self.internal_metrics.pop(current.ident)
+                        # Build labels dict in one operation instead of multiple updates
+                        labels = {
+                            "bundle_id": bundle_id,
+                            "collector_name": sensor,
+                            **params  # Unpack params directly
+                        }
+                        stats_collector = get_metrics_collector()
+                        stats_collector.record_metric(labels=labels, metrics=metrics)
+                except Exception as exc:
+                    self.logger.debug(MSG['HttpMetricsRecordFailed'].format(exc))
             return resString
 
         # /metrics
@@ -201,6 +429,41 @@ class PrometheusExporter(object):
                 labels = self.TOPO.getSensorLabels(v)
                 if labels:
                     resp[k] = labels
+            cherrypy.response.headers['Content-Type'] = 'application/json'
+            resp = json.dumps(resp)
+            return resp
+
+        # /bundle_ids - List all registered Prometheus bundle IDs (only if http_metrics_enabled)
+        elif '/bundle_ids' == cherrypy.request.script_name:
+            if not analytics.http_metrics_enabled:
+                self.logger.error(MSG['BundleIdTrackingDisabled'])
+                raise cherrypy.HTTPError(503, MSG['BundleIdTrackingDisabled'])
+
+            if params.get('bundle_id'):
+                # Get specific bundle ID info
+                bundle_id = params.get('bundle_id')
+                info = get_prometheus_bundle_info(bundle_id)
+                if info:
+                    resp = {
+                        'bundle_id': bundle_id,
+                        'found': True,
+                        'info': info
+                    }
+                else:
+                    resp = {
+                        'bundle_id': bundle_id,
+                        'found': False,
+                        'message': MSG['BundleIdNotFound']
+                    }
+            else:
+                # List all bundle IDs with stats
+                all_bundles = get_all_prometheus_bundle_ids()
+                stats = get_prometheus_bundle_registry_stats()
+                resp = {
+                    'registry_type': 'prometheus',
+                    'stats': stats,
+                    'bundles': all_bundles
+                }
             cherrypy.response.headers['Content-Type'] = 'application/json'
             resp = json.dumps(resp)
             return resp

--- a/source/prometheus.py
+++ b/source/prometheus.py
@@ -21,13 +21,12 @@ Created on Oct 30, 2023
 '''
 
 import cherrypy
-import copy
 import json
 import sys
 import analytics
 from functools import lru_cache
 from messages import ERR, MSG
-from typing import Optional, Union, List, Tuple, Dict, Any
+from typing import Optional, Union, Dict, Any
 from collections import OrderedDict, defaultdict
 from threading import Lock
 from cherrypy.process.plugins import Monitor
@@ -43,6 +42,7 @@ from utils import execution_time, cond_execution_time, get_request_host
 _prometheus_bundle_registry: OrderedDict[str, Dict[str, Any]] = OrderedDict()
 _prometheus_registry_lock = Lock()
 _PROMETHEUS_MAX_REGISTRY_SIZE = 100  # Keep last 100 bundle_ids for debugging
+
 
 def _normalize_prometheus_request(sensors: list, filters: Optional[dict] = None) -> dict:
     """Extract and normalize Prometheus request parameters for consistent hashing."""

--- a/source/queryHandler/PerfmonRESTclient.py
+++ b/source/queryHandler/PerfmonRESTclient.py
@@ -103,7 +103,7 @@ class perfHTTPrequestHelper(object):
         self.requestData = reqdata
         self.logger = logger
 
-    @cond_execution_time(enabled=analytics.inspect)
+    @cond_execution_time(detail_level=4)
     def doRequest(self):
         if self.requestData and isinstance(self.requestData, requests.Request):
             self.session.verify = self.caCert

--- a/source/queryHandler/QueryHandler.py
+++ b/source/queryHandler/QueryHandler.py
@@ -27,7 +27,7 @@ import time
 import analytics
 from collections import namedtuple, defaultdict
 from itertools import chain
-from typing import NamedTuple, Tuple
+from typing import NamedTuple, Tuple, Union
 from utils import cond_execution_time, get_runtime_statistics
 
 from .PerfmonRESTclient import perfHTTPrequestHelper, createRequestDataObj, getAuthHandler
@@ -428,6 +428,7 @@ class QueryHandler2:
         self.remote_ip = socket.gethostbyname(server)
         self.port = port
         self.logger = logger
+        self.internal_metrics: defaultdict[int, dict[str, Union[int, float]]] = defaultdict(dict)
 
     @property
     def apiKeyData(self):
@@ -437,7 +438,7 @@ class QueryHandler2:
     def caCert(self):
         return self.__caCert
 
-    @cond_execution_time(enabled=analytics.inspect)
+    @cond_execution_time(detail_level=3)
     def getTopology(self, ignoreMetrics=False):
         '''
         Returns complete topology as a single JSON string
@@ -487,7 +488,7 @@ class QueryHandler2:
             self.logger.error(
                 'QueryHandler: deleteKeysFromTopology response not valid json: {0} {1}'.format(response[:20], e))
 
-    @cond_execution_time(enabled=analytics.inspect)
+    @cond_execution_time(detail_level=3)
     def runQuery(self, query):
         '''
         runQuery: executes the given query based on the arguments.
@@ -529,6 +530,14 @@ class QueryHandler2:
                 # only terminates after the whole message has been received (Time-To-Last-Byte, TTLB).
                 if analytics.requests_elapsed_time:
                     self.logger.debug(f'response elapsed time: {_response.elapsed.total_seconds()} for request: {str(params)}')
+                if analytics.http_metrics_enabled:
+                    response_size = len(_response.content)
+                    duration = _response.elapsed.total_seconds()
+                    import threading
+                    current = threading.current_thread()
+                    if current.ident is not None:
+                        self.internal_metrics[current.ident]['perfmon_response_duration'] = duration
+                        self.internal_metrics[current.ident]['perfmon_response_amount'] = response_size
                 return _response.content.decode('utf-8', "strict")
             elif _response.status_code == 401:
                 self.logger.trace('Request headers:{}'.format(_response.request.headers))

--- a/source/stats.py
+++ b/source/stats.py
@@ -21,7 +21,6 @@ Created on Apr 17, 2026
 '''
 
 import time
-import copy
 import cherrypy
 import json
 import sys
@@ -351,7 +350,7 @@ class HTTPMetricsCollector:
         return output.getvalue()
 
     def get_opentsdb_metrics(self, limit: Optional[int] = None,
-                            aggregated_tags: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+                             aggregated_tags: Optional[List[str]] = None) -> List[Dict[str, Any]]:
         """
         Generate OpenTSDB format metrics.
         The response format follows the OpenTSDB specification at:
@@ -370,7 +369,6 @@ class HTTPMetricsCollector:
                 },
                 ...
             ]
-            
         Example:
             >>> collector.record_metric(
             ...     labels={"bundle_id": "abc123", "collector_name": "test"},
@@ -522,7 +520,6 @@ class HTTPMetricsAPI:
             supported_formats = ['json', 'prometheus', 'csv', 'opentsdb', 'stats']
             if format not in supported_formats:
                 raise cherrypy.HTTPError(400, f"Unsupported format '{format}'. Supported formats: {', '.join(supported_formats)}")
-            
             try:
                 if format == 'prometheus':
                     metrics_lines = self.collector.get_prometheus_metrics()

--- a/source/stats.py
+++ b/source/stats.py
@@ -1,0 +1,570 @@
+'''
+##############################################################################
+# Copyright 2026 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+Created on Apr 17, 2026
+
+@author: hwassman
+'''
+
+import time
+import copy
+import cherrypy
+import json
+import sys
+from collections import defaultdict, deque
+from threading import Lock, Timer
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class HTTPRequestMetric:
+    """Data class for storing HTTP request metrics"""
+    timestamp: float
+    labels: Dict[str, Any]
+    metrics: Dict[str, Any]
+
+    def convert_bundle_to_metrics_timeseries(self) -> Dict[str, List[Dict[str, Any]]]:
+        """
+        Convert bundle metrics to time series format.
+        Returns:
+            Dictionary mapping metric names to lists of time series data points
+        """
+        sorted_metrics: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        # deep copy labels
+        labels = self.labels.copy()
+        timestamp = self.timestamp
+
+        for key, value in self.metrics.items():
+            # Create dict in one operation instead of multiple updates
+            timeserie = {
+                "labels": labels,
+                "value": value,
+                "timestamp": timestamp
+            }
+            sorted_metrics[key].append(timeserie)
+
+        # Return defaultdict directly - no need to convert to regular dict
+        return sorted_metrics
+
+
+class HTTPMetricsCollector:
+    """
+    Collects and stores HTTP request/response metrics for monitoring.
+    Thread-safe implementation with configurable retention and automatic cleanup.
+    Features:
+    - Thread-safe metric collection using locks
+    - Configurable maximum history size
+    - Automatic cleanup of old metrics via periodic background task
+    - Prometheus exposition format support
+    The collector automatically removes metrics older than retention_seconds
+    by running a background cleanup task at regular intervals (cleanup_interval).
+    """
+
+    def __init__(self, max_history: int = 1000, retention_seconds: int = 3600, cleanup_interval: int = 300):
+        """
+        Initialize the metrics collector.
+        Args:
+            max_history: Maximum number of metrics to keep in memory
+            retention_seconds: How long to keep metrics (in seconds)
+            cleanup_interval: How often to run cleanup (in seconds, default: 300 = 5 minutes)
+        """
+        self.max_history = max_history
+        self.retention_seconds = retention_seconds
+        self.cleanup_interval = cleanup_interval
+        self.metrics: deque = deque(maxlen=max_history)
+        self.lock = Lock()
+
+        # Aggregated statistics
+        self.stats = {'total_requests': 0}
+
+        # Cleanup timer
+        self._cleanup_timer: Optional[Timer] = None
+        self._cleanup_running = False
+
+    def record_metric(self, labels: dict, metrics: dict):
+        """
+        Record a new HTTP request metric.
+        Args:
+            endpoint: The API endpoint path
+            method: HTTP method (GET, POST, etc.)
+            status_code: HTTP status code
+            request_size: Request body size in bytes
+            response_size: Response body size in bytes
+            duration: Request duration in seconds
+            remote_addr: Remote client address
+        """
+        metric = HTTPRequestMetric(
+            timestamp=time.time(),
+            labels=labels,
+            metrics=metrics
+        )
+
+        with self.lock:
+            self.metrics.append(metric)
+
+            # Update aggregated statistics
+            self.stats['total_requests'] += 1
+
+    def cleanup_old_metrics(self):
+        """Remove metrics older than retention_seconds"""
+        cutoff_time = time.time() - self.retention_seconds
+        with self.lock:
+            while self.metrics and self.metrics[0].timestamp < cutoff_time:
+                self.metrics.popleft()
+
+    def start_periodic_cleanup(self):
+        """Start periodic cleanup using threading.Timer"""
+        if self._cleanup_running:
+            return
+        self._cleanup_running = True
+        self._schedule_cleanup()
+
+    def _schedule_cleanup(self):
+        """Internal method to schedule the next cleanup"""
+        if not self._cleanup_running:
+            return
+        try:
+            self.cleanup_old_metrics()
+        except Exception as e:
+            # Log error but continue scheduling
+            print(f"Error during metrics cleanup: {e}", file=sys.stderr)
+        # Schedule next cleanup
+        self._cleanup_timer = Timer(self.cleanup_interval, self._schedule_cleanup)
+        self._cleanup_timer.daemon = True
+        self._cleanup_timer.start()
+
+    def stop_periodic_cleanup(self):
+        """Stop periodic cleanup"""
+        self._cleanup_running = False
+        if self._cleanup_timer:
+            self._cleanup_timer.cancel()
+            self._cleanup_timer = None
+
+    def get_recent_metrics(self, limit: Optional[int] = None) -> List[Dict]:
+        """
+        Get recent metrics as a list of dictionaries.
+        Args:
+            limit: Maximum number of metrics to return (None for all)
+        Returns:
+            List of metric dictionaries
+        """
+        with self.lock:
+            metrics_list = list(self.metrics)
+            if limit:
+                metrics_list = metrics_list[-limit:]
+            return metrics_list
+
+    def get_metrics_last_5_minutes(self) -> List['HTTPRequestMetric']:
+        """
+        Get metrics from the last 5 minutes.
+        This method leverages the fact that metrics are stored in chronological order
+        (oldest first) in the deque, allowing for efficient filtering.
+        Returns:
+            List of HTTPRequestMetric objects with timestamps from the last 5 minutes
+        """
+        cutoff_time = time.time() - 300  # 300 seconds = 5 minutes
+        # print(f"cutoff_time: {cutoff_time}")
+        # print(f"cutoff_time int: {(int(time.time()) * 1000) - 300}")
+
+        with self.lock:
+            # Since deque is ordered by timestamp (oldest first), we can find the first
+            # metric that's within our time window and slice from there
+            metrics_list = list(self.metrics)
+
+            # Binary search for the first metric >= cutoff_time
+            left, right = 0, len(metrics_list)
+            while left < right:
+                mid = (left + right) // 2
+                if metrics_list[mid].timestamp < cutoff_time:
+                    left = mid + 1
+                else:
+                    right = mid
+
+            # Extract only the metrics dict from matching HTTPRequestMetric objects
+            return metrics_list[left:]
+
+    def get_statistics(self) -> Dict:
+        """
+        Get aggregated statistics.
+        Returns:
+            Dictionary containing aggregated statistics
+        """
+        with self.lock:
+            memory_size = sys.getsizeof(self.metrics) + sum(sys.getsizeof(obj) for obj in self.metrics)
+            stats_copy = {
+                'total_requests': self.stats['total_requests'],
+                # 'total_request_bytes': self.stats['total_request_bytes'],
+                # 'total_response_bytes': self.stats['total_response_bytes'],
+                # 'total_transfer_bytes': self.stats['total_request_bytes'] + self.stats['total_response_bytes'],
+                # 'by_endpoint': dict(self.stats['by_endpoint']),
+                # 'by_status': dict(self.stats['by_status']),
+                'metrics_in_memory_count': len(self.metrics),
+                'metrics_in_memory_size': memory_size
+            }
+
+        try:
+            from opentsdb import get_bundle_registry_stats
+            from prometheus import get_prometheus_bundle_registry_stats
+
+            opentsdb_stats = get_bundle_registry_stats()
+            prometheus_stats = get_prometheus_bundle_registry_stats()
+
+            opentsdb_count = opentsdb_stats.get('size', 0)
+            prometheus_count = prometheus_stats.get('size', 0)
+            opentsdb_memory_size = opentsdb_stats.get('memory_size', 0)
+            prometheus_memory_size = prometheus_stats.get('memory_size', 0)
+
+            stats_copy.update({
+                'opentsdb_bundle_ids_count': opentsdb_count,
+                'prometheus_bundle_ids_count': prometheus_count,
+                'bundle_ids_count_total': opentsdb_count + prometheus_count,
+                'opentsdb_bundle_registry_memory_size': opentsdb_memory_size,
+                'prometheus_bundle_registry_memory_size': prometheus_memory_size,
+                'bundle_registry_memory_size_total': opentsdb_memory_size + prometheus_memory_size,
+            })
+        except Exception:
+            pass
+
+        return stats_copy
+
+    def get_prometheus_metrics(self, metric_prefix='grafana_bridge') -> List[str]:
+        """
+        Generate Prometheus exposition format metrics from the last 5 minutes.
+        Args:
+            metric_prefix: Prefix for metric names (currently unused)
+        Returns:
+            List of formatted metric lines in Prometheus exposition format
+        """
+        metrics = self.get_metrics_last_5_minutes()
+        # Use defaultdict to avoid setdefault calls
+        merged: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for metric in metrics:
+            bundle_timeseries = metric.convert_bundle_to_metrics_timeseries()
+            for key, value in bundle_timeseries.items():
+                merged[key].extend(value)
+
+        # Build output lines
+        lines = []
+        lines_append = lines.append  # Cache method reference for performance
+
+        for key, value in merged.items():
+            actor, method = key.split("_", 1)
+            if not any(sub in key for sub in ("size", "amount", "bytes", "content")):
+                description = f'time in seconds how long {actor} took to complete {method}'
+            else:
+                description = f'bytes received by {actor} though {method} completion'
+
+            lines_append(f'# HELP {key} {description}')
+            lines_append(f'# TYPE {key} gauge')
+
+            # Inline metric_exprfmt for better performance
+            for timeserie in value:
+                labels_dict = timeserie.get("labels")
+                if labels_dict:
+                    labels = ','.join(f'{k}="{v}"' for k, v in labels_dict.items())
+                    fmtstr = f"{key}{{{labels}}} {timeserie['value']} {int(timeserie['timestamp']) * 1000}"
+                else:
+                    fmtstr = f"{key} {timeserie['value']} {int(timeserie['timestamp']) * 1000}"
+                lines_append(fmtstr)
+
+        return lines
+
+    def get_csv_metrics(self, limit: Optional[int] = None) -> str:
+        """
+        Generate CSV format metrics with flexible headers.
+        Args:
+            limit: Maximum number of metrics to include (None for all available metrics)
+                   Default is None to export all metrics in memory (up to max_history)
+        Returns:
+            String containing CSV formatted metrics with header
+        Performance Note:
+            With default max_history=1000, processing all metrics typically takes < 100ms.
+            Use limit parameter to reduce processing time for very large datasets.
+        """
+        import csv
+        from io import StringIO
+
+        # Get all recent metrics or limited subset
+        metrics = self.get_recent_metrics(limit=limit)
+
+        # Collect all unique label keys across all metrics
+        all_label_keys = set()
+        rows_data = []
+
+        for metric in metrics:
+            bundle_timeseries = metric.convert_bundle_to_metrics_timeseries()
+            for metric_name, timeseries_list in bundle_timeseries.items():
+                for timeserie in timeseries_list:
+                    labels_dict = timeserie.get("labels", {})
+                    all_label_keys.update(labels_dict.keys())
+
+                    # Store row data for later processing
+                    rows_data.append({
+                        'timestamp': timeserie['timestamp'],
+                        'metric_name': metric_name,
+                        'labels': labels_dict,
+                        'value': timeserie['value']
+                    })
+
+        # Sort label keys for consistent column ordering
+        sorted_label_keys = sorted(all_label_keys)
+
+        # Build CSV header
+        header = ['timestamp', 'metric_name'] + sorted_label_keys + ['value']
+
+        # Generate CSV content
+        output = StringIO()
+        writer = csv.writer(output)
+        writer.writerow(header)
+
+        # Write data rows
+        for row_data in rows_data:
+            row = [
+                datetime.fromtimestamp(row_data['timestamp']).strftime('%Y-%m-%d %H:%M:%S'),
+                row_data['metric_name']
+            ]
+
+            # Add label values in the same order as header
+            for label_key in sorted_label_keys:
+                row.append(row_data['labels'].get(label_key, ''))
+
+            # Add metric value
+            row.append(row_data['value'])
+            writer.writerow(row)
+
+        return output.getvalue()
+
+    def get_opentsdb_metrics(self, limit: Optional[int] = None,
+                            aggregated_tags: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """
+        Generate OpenTSDB format metrics.
+        The response format follows the OpenTSDB specification at:
+        https://opentsdb.net/docs/build/html/api_http/query/index.html
+        Args:
+            limit: Maximum number of metrics to include (None for all available metrics)
+            aggregated_tags: Optional list of tag names that were aggregated over
+        Returns:
+            List of dictionaries, each representing a time series in OpenTSDB format:
+            [
+                {
+                    "metric": "<metric_name>",
+                    "tags": {<label_key>: <label_value>, ...},
+                    "aggregatedTags": [<tag_name>, ...],
+                    "dps": {<timestamp_ms>: <value>, ...}
+                },
+                ...
+            ]
+            
+        Example:
+            >>> collector.record_metric(
+            ...     labels={"bundle_id": "abc123", "collector_name": "test"},
+            ...     metrics={"request_count": 100, "response_time_ms": 250}
+            ... )
+            >>> response = collector.get_opentsdb_metrics()
+            >>> print(response)
+            [
+                {
+                    "metric": "request_count",
+                    "tags": {"bundle_id": "abc123", "collector_name": "test"},
+                    "aggregatedTags": [],
+                    "dps": {"1609459200000": 100}
+                },
+                {
+                    "metric": "response_time_ms",
+                    "tags": {"bundle_id": "abc123", "collector_name": "test"},
+                    "aggregatedTags": [],
+                    "dps": {"1609459200000": 250}
+                }
+            ]
+        """
+        metrics_list = self.get_recent_metrics(limit=limit)
+        # Dictionary to group time series by (metric_name, labels_tuple)
+        timeseries_map: Dict[tuple, Dict[str, Any]] = {}
+        for http_metric in metrics_list:
+            timestamp_ms = str(int(http_metric.timestamp * 1000))
+
+            # Create a hashable key from labels for grouping
+            labels_key = frozenset(http_metric.labels.items())
+
+            # Process each metric in the HTTPRequestMetric
+            for metric_name, metric_value in http_metric.metrics.items():
+                # Create unique key for this time series
+                ts_key = (metric_name, labels_key)
+                # Initialize time series entry if not exists
+                if ts_key not in timeseries_map:
+                    timeseries_map[ts_key] = {
+                        "metric": metric_name,
+                        "tags": http_metric.labels.copy(),
+                        "aggregatedTags": aggregated_tags or [],
+                        "dps": {}
+                    }
+
+                # Add datapoint to this time series
+                timeseries_map[ts_key]["dps"][timestamp_ms] = metric_value
+
+        # Convert map to list of response objects
+        return list(timeseries_map.values())
+
+    def reset_statistics(self):
+        """Reset all statistics and clear metrics history"""
+        with self.lock:
+            self.metrics.clear()
+            self.stats = {
+                'total_requests': 0,
+            }
+
+
+# Global metrics collector instance
+_metrics_collector: Optional[HTTPMetricsCollector] = None
+
+
+def get_metrics_collector() -> HTTPMetricsCollector:
+    """Get or create the global metrics collector instance"""
+    global _metrics_collector
+    if _metrics_collector is None:
+        _metrics_collector = HTTPMetricsCollector()
+    return _metrics_collector
+
+
+class HTTPMetricsAPI:
+    """REST API endpoint for accessing HTTP metrics"""
+    exposed = True
+
+    def __init__(self, logger):
+        self.logger = logger
+        self.collector = get_metrics_collector()
+
+    def GET(self, **params):
+        """
+        Get HTTP metrics or bundle IDs.
+        Query parameters:
+            format: 'prometheus' (default), 'json', 'csv', 'opentsdb', or 'stats' (for /http_metrics)
+            limit: Number of recent metrics to return (for json format)
+            bundle_id: Specific bundle ID to retrieve (for /bundle_ids)
+            registry: 'opentsdb', 'prometheus', or 'all' (default 'all') (for /bundle_ids)
+        """
+        format = params.get('format', 'prometheus')
+        limit = params.get('limit', None)
+        bundle_id = params.get('bundle_id', None)
+        registry = params.get('registry', 'all')
+        # /bundle_ids - Unified endpoint for both OpenTSDB and Prometheus bundle IDs
+        if '/bundle_ids' == cherrypy.request.script_name:
+            try:
+                from opentsdb import get_bundle_info, get_all_bundle_ids, get_bundle_registry_stats
+                from prometheus import get_prometheus_bundle_info, get_all_prometheus_bundle_ids, get_prometheus_bundle_registry_stats
+                if bundle_id:
+                    # Get specific bundle ID from requested registry/registries
+                    result = {
+                        'bundle_id': bundle_id,
+                        'registries': {}
+                    }
+
+                    if registry in ['all', 'opentsdb']:
+                        opentsdb_info = get_bundle_info(bundle_id)
+                        result['registries']['opentsdb'] = {
+                            'found': opentsdb_info is not None,
+                            'info': opentsdb_info if opentsdb_info else None
+                        }
+
+                    if registry in ['all', 'prometheus']:
+                        prometheus_info = get_prometheus_bundle_info(bundle_id)
+                        result['registries']['prometheus'] = {
+                            'found': prometheus_info is not None,
+                            'info': prometheus_info if prometheus_info else None
+                        }
+
+                    cherrypy.response.headers['Content-Type'] = 'application/json'
+                    return json.dumps(result)
+                else:
+                    # List all bundle IDs from requested registry/registries
+                    result = {
+                        'registries': {}
+                    }
+
+                    if registry in ['all', 'opentsdb']:
+                        result['registries']['opentsdb'] = {
+                            'stats': get_bundle_registry_stats(),
+                            'bundles': get_all_bundle_ids()
+                        }
+
+                    if registry in ['all', 'prometheus']:
+                        result['registries']['prometheus'] = {
+                            'stats': get_prometheus_bundle_registry_stats(),
+                            'bundles': get_all_prometheus_bundle_ids()
+                        }
+
+                    cherrypy.response.headers['Content-Type'] = 'application/json'
+                    return json.dumps(result)
+
+            except Exception as e:
+                self.logger.error(f'Error retrieving bundle IDs: {e}')
+                raise cherrypy.HTTPError(500, f'Error retrieving bundle IDs: {str(e)}')
+
+        # /http_metrics
+        elif '/http_metrics' == cherrypy.request.script_name:
+            # Validate format parameter
+            supported_formats = ['json', 'prometheus', 'csv', 'opentsdb', 'stats']
+            if format not in supported_formats:
+                raise cherrypy.HTTPError(400, f"Unsupported format '{format}'. Supported formats: {', '.join(supported_formats)}")
+            
+            try:
+                if format == 'prometheus':
+                    metrics_lines = self.collector.get_prometheus_metrics()
+                    cherrypy.response.headers['Content-Type'] = 'text/plain; charset=utf-8'
+                    resString = '\n'.join(metrics_lines) + '\n'
+                    return resString
+                elif format == 'opentsdb':
+                    opentsdb_response = self.collector.get_opentsdb_metrics()
+                    cherrypy.response.headers['Content-Type'] = 'application/json'
+                    return json.dumps(opentsdb_response)
+                elif format == 'csv':
+                    limit_int = int(limit) if limit else None
+                    csv_content = self.collector.get_csv_metrics(limit=limit_int)
+                    cherrypy.response.headers['Content-Type'] = 'text/csv; charset=utf-8'
+                    cherrypy.response.headers['Content-Disposition'] = 'attachment; filename="http_metrics.csv"'
+                    return csv_content
+                elif format == 'stats':
+                    resp = self.collector.get_statistics()
+                    cherrypy.response.headers['Content-Type'] = 'application/json'
+                    return json.dumps(resp)
+                else:  # json format
+                    limit_int = int(limit) if limit else None
+                    return {
+                        'metrics': self.collector.get_recent_metrics(limit=limit_int),
+                        'statistics': self.collector.get_statistics()
+                    }
+            except Exception as e:
+                self.logger.error(f'Error retrieving HTTP metrics: {e}')
+                raise cherrypy.HTTPError(500, f'Error retrieving metrics: {str(e)}')
+        # /internal_stat
+        elif '/internal_stats' == cherrypy.request.script_name:
+            resp = self.collector.get_statistics()
+            cherrypy.response.headers['Content-Type'] = 'application/json'
+            return json.dumps(resp)
+
+    @cherrypy.tools.json_out()
+    def DELETE(self):
+        """Reset all metrics and statistics"""
+        try:
+            self.collector.reset_statistics()
+            self.logger.info('HTTP metrics reset successfully')
+            return {'status': 'success', 'message': 'Metrics reset successfully'}
+        except Exception as e:
+            self.logger.error(f'Error resetting HTTP metrics: {e}')
+            raise cherrypy.HTTPError(500, f'Error resetting metrics: {str(e)}')

--- a/source/utils.py
+++ b/source/utils.py
@@ -22,6 +22,9 @@ Created on Oct 25, 2023
 
 import time
 import copy
+import cherrypy
+import analytics
+import threading
 from threading import Lock
 from typing import Callable, TypeVar, Any
 from functools import wraps
@@ -31,74 +34,19 @@ from profiler import Profiler
 T = TypeVar('T')
 
 
-def execution_time(skip_attribute: bool = False) -> Callable[[Callable[..., T]], Callable[..., T]]:
-    """ Logs the name of the given function f with  passed parameter values
-        and the time it takes to execute it.
+def get_request_host() -> str:
     """
-    def outer(f: Callable[..., T]) -> Callable[..., T]:
-        @wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> T:
-            self = args[0]
-            args_str = ', '.join(map(str, args[1:])) if len(args) > 1 else ''
-            kwargs_str = ', '.join(f'{k}={v}' for k, v in kwargs.items()) if len(kwargs) > 0 else ''
-            self.logger.trace(MSG['StartMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
-            t1 = time.perf_counter(), time.process_time()
-            result = f(*args, **kwargs)
-            t2 = time.perf_counter(), time.process_time()
-            duration = t2[0] - t1[0]
-            cpu_time = t2[1] - t1[1]
-            if not skip_attribute:
-                wrapper._execution_duration = duration  # type: ignore
-            self.logger.debug(MSG['RunMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
-            self.logger.debug(MSG['TimerInfo'].format(f.__name__, duration, cpu_time))
-            return result
-        return wrapper
-    return outer
-
-
-def cond_execution_time(enabled: bool = False, skip_attribute: bool = False) -> Callable[[Callable[..., T]], Callable[..., T]]:
-    """ Conditionally logs the name of the given function f with
-        passed parameter values and the time it takes to execute it.
+    Extract host (without port) from cherrypy request headers.
+    
+    Returns:
+        Host string without port, or 'unknown' if not available
     """
-    def outer(f: Callable[..., T]) -> Callable[..., T]:
-        @wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> T:
-            self = args[0]
-            if hasattr(self, 'logger'):
-                logger = self.logger
-            else:
-                from bridgeLogger import getBridgeLogger
-                logger = getBridgeLogger()
-            args_str = ', '.join(map(str, args[1:])) if len(args) > 1 else ''
-            kwargs_str = ', '.join(f'{k}={v}' for k, v in kwargs.items()) if len(kwargs) > 0 else ''
-            logger.trace(MSG['StartMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
-            t1 = time.perf_counter(), time.process_time()
-            result = f(*args, **kwargs)
-            t2 = time.perf_counter(), time.process_time()
-            duration = t2[0] - t1[0]
-            cpu_time = t2[1] - t1[1]
-            if not skip_attribute:
-                wrapper._execution_duration = duration  # type: ignore
-            logger.debug(MSG['RunMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
-            logger.debug(MSG['TimerInfo'].format(f.__name__, duration, cpu_time))
-            return result
-        return wrapper
-
-    def no_outer(f: Callable[..., T]) -> Callable[..., T]:
-        return f
-    return outer if enabled else no_outer
-
-
-def synchronized(lock: Lock):
-    """Decorator which takes a Lock and runs the function under that Lock"""
-    def funcWrapper(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            with lock:
-                ret = func(*args, **kwargs)
-            return ret
-        return wrapper
-    return funcWrapper
+    try:
+        host_header = cherrypy.request.headers.get('Host', '')
+        host = host_header.split(':')[0] if host_header else 'unknown'
+        return host
+    except Exception:
+        return 'unknown'
 
 
 def get_runtime_statistics(enabled: bool = False) -> Callable[[Callable[..., T]], Callable[..., T]]:
@@ -115,6 +63,149 @@ def get_runtime_statistics(enabled: bool = False) -> Callable[[Callable[..., T]]
     def no_outer(f: Callable[..., T]) -> Callable[..., T]:
         return f
     return outer if enabled else no_outer
+
+
+@get_runtime_statistics(enabled=analytics.runtime_profiling)
+def execution_time() -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """ Logs the name of the given function f with  passed parameter values
+        and the time it takes to execute it.
+    """
+    def outer(f: Callable[..., T]) -> Callable[..., T]:
+        @wraps(f)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            self = args[0]
+
+            # self.logger.trace(MSG['StartMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
+            t1 = time.perf_counter(), time.process_time()
+            result = f(*args, **kwargs)
+            t2 = time.perf_counter(), time.process_time()
+            duration = t2[0] - t1[0]
+            cpu_time = t2[1] - t1[1]
+            # keep as alternative following line
+            # wrapper._execution_duration = duration
+
+            # Check if httpMetrics is enabled via analytics module
+            if analytics.http_metrics_enabled and hasattr(self, 'internal_metrics'):
+                try:
+                    import threading
+                    current = threading.current_thread()
+                    # Use the class name as prefix
+                    class_name = self.__class__.__name__
+                    metric_name = f"{class_name}_{f.__name__}"
+                    self.internal_metrics[current.ident][metric_name] = self.internal_metrics[current.ident].get(metric_name, 0) + duration
+                    # metric_count = f"{metric_name}_count"
+                    # self.internal_metrics[current.ident][metric_count] = self.internal_metrics[current.ident].get(metric_count, 0) + 1
+                except Exception as e:
+                    self.logger.error(MSG['InternalExecutionMetricsCacheFailed'].format(e))
+            elif not analytics.http_metrics_enabled:
+                args_str = ', '.join(map(str, args[1:])) if len(args) > 1 else ''
+                kwargs_str = ', '.join(f'{k}={v}' for k, v in kwargs.items()) if len(kwargs) > 0 else ''
+                self.logger.debug(MSG['RunMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
+                self.logger.debug(MSG['TimerInfo'].format(f.__name__, duration, cpu_time))
+            else:
+                self.logger.trace(f'{f.__name__} does not have internal metrics')
+            return result
+        return wrapper
+    return outer
+
+
+@get_runtime_statistics(enabled=analytics.runtime_profiling)
+def cond_execution_time(detail_level: int = 1) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """ Wrapper method that measures execution time of wrapped methods.
+    
+    This decorator conditionally logs the name of the given function with
+    passed parameter values and the time it takes to execute it, based on
+    the analytics.inspect_special detail level setting.
+    The wrapper only executes timing measurements if the global
+    analytics.inspect_special setting is greater than or equal to the
+    specified detail_level. This allows fine-grained control over which
+    methods are profiled based on the desired level of detail.
+    Args:
+        detail_level: Required detail level (1-5). The wrapper only measures
+                     execution time if analytics.inspect_special >= detail_level.
+                     Level 1 = basic profiling, Level 5 = most detailed profiling.
+     Returns:
+        A decorator that wraps the function with execution time measurement,
+        or returns the original function unchanged if detail level is insufficient.
+    Example:
+        @cond_execution_time(detail_level=3)
+        def my_method(self):
+            # This will only be timed if analytics.inspect_special >= 3
+            pass
+    """
+    # Check analytics settings at decoration time
+    should_measure = analytics.inspect_special >= detail_level
+    
+    def outer(f: Callable[..., T]) -> Callable[..., T]:
+        # Pre-compute metric name prefix for detail_levels 2-4 (optimization)
+        if detail_level == 4:
+            metric_prefix = "perfmon_"
+        elif detail_level == 3:
+            metric_prefix = "qh_"
+        elif detail_level == 2:
+            metric_prefix = "collector_"
+        else:
+            metric_prefix = None
+            
+        @wraps(f)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            self = args[0]
+            if hasattr(self, 'logger'):
+                logger = self.logger
+            else:
+                from bridgeLogger import getBridgeLogger
+                logger = getBridgeLogger()
+
+            # logger.trace(MSG['StartMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
+            t1 = time.perf_counter(), time.process_time()
+            result = f(*args, **kwargs)
+            t2 = time.perf_counter(), time.process_time()
+            duration = t2[0] - t1[0]
+            cpu_time = t2[1] - t1[1]
+            # wrapper._execution_duration = duration  # type: ignore
+
+            # Check if httpMetrics is enabled via analytics module
+            if analytics.http_metrics_enabled and hasattr(self, 'internal_metrics'):
+                try:
+                    current = threading.current_thread()
+                    # Determine metric name using pre-computed prefix
+                    if metric_prefix:
+                        metric_name = f"{metric_prefix}{f.__name__}"
+                    elif detail_level == 1:
+                        # Use the class name as prefix
+                        metric_name = f"{self.__class__.__name__}_{f.__name__}"
+                    else:
+                        metric_name = f.__name__
+                    self.internal_metrics[current.ident][metric_name] = self.internal_metrics[current.ident].get(metric_name, 0) + duration
+                    # metric_count = f"{metric_name}_count"
+                    # self.internal_metrics[current.ident][metric_count] = self.internal_metrics[current.ident].get(metric_count, 0) + 1
+                except Exception as e:
+                    logger.error(MSG['InternalExecutionMetricsCacheFailed'].format(e))
+            elif not analytics.http_metrics_enabled:
+                args_str = ', '.join(map(str, args[1:])) if len(args) > 1 else ''
+                kwargs_str = ', '.join(f'{k}={v}' for k, v in kwargs.items()) if len(kwargs) > 0 else ''
+                logger.debug(MSG['RunMethod'].format(f.__name__, ', '.join(filter(None, [args_str, kwargs_str]))))
+                logger.debug(MSG['TimerInfo'].format(f.__name__, duration, cpu_time))
+            else:
+                logger.trace(f'{f.__name__} does not have internal metrics')
+            return result
+        return wrapper
+
+    def no_outer(f: Callable[..., T]) -> Callable[..., T]:
+        return f
+    return outer if should_measure else no_outer
+
+
+def synchronized(lock: Lock):
+    """Decorator which takes a Lock and runs the function under that Lock"""
+    def funcWrapper(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with lock:
+                ret = func(*args, **kwargs)
+            return ret
+        return wrapper
+    return funcWrapper
 
 
 def classattributes(default_attr: dict, more_allowed_attr: list):

--- a/source/utils.py
+++ b/source/utils.py
@@ -26,7 +26,7 @@ import cherrypy
 import analytics
 import threading
 from threading import Lock
-from typing import Callable, TypeVar
+from typing import Any, Callable, TypeVar
 from functools import wraps
 from messages import MSG
 from profiler import Profiler

--- a/source/utils.py
+++ b/source/utils.py
@@ -26,7 +26,7 @@ import cherrypy
 import analytics
 import threading
 from threading import Lock
-from typing import Callable, TypeVar, Any
+from typing import Callable, TypeVar
 from functools import wraps
 from messages import MSG
 from profiler import Profiler
@@ -37,7 +37,6 @@ T = TypeVar('T')
 def get_request_host() -> str:
     """
     Extract host (without port) from cherrypy request headers.
-    
     Returns:
         Host string without port, or 'unknown' if not available
     """
@@ -112,7 +111,6 @@ def execution_time() -> Callable[[Callable[..., T]], Callable[..., T]]:
 @get_runtime_statistics(enabled=analytics.runtime_profiling)
 def cond_execution_time(detail_level: int = 1) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """ Wrapper method that measures execution time of wrapped methods.
-    
     This decorator conditionally logs the name of the given function with
     passed parameter values and the time it takes to execute it, based on
     the analytics.inspect_special detail level setting.
@@ -135,7 +133,7 @@ def cond_execution_time(detail_level: int = 1) -> Callable[[Callable[..., T]], C
     """
     # Check analytics settings at decoration time
     should_measure = analytics.inspect_special >= detail_level
-    
+
     def outer(f: Callable[..., T]) -> Callable[..., T]:
         # Pre-compute metric name prefix for detail_levels 2-4 (optimization)
         if detail_level == 4:
@@ -146,7 +144,7 @@ def cond_execution_time(detail_level: int = 1) -> Callable[[Callable[..., T]], C
             metric_prefix = "collector_"
         else:
             metric_prefix = None
-            
+
         @wraps(f)
         def wrapper(*args: Any, **kwargs: Any) -> T:
             self = args[0]

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -45,6 +45,7 @@ from watcher import ConfigWatcher
 from resthelper import RestHelpGenerator
 from cherrypy import _cperror
 from cherrypy.lib.cpstats import StatsPage
+from stats import HTTPMetricsAPI, get_metrics_collector
 
 ENDPOINTS = {}
 AUTH_DICT = {}
@@ -428,6 +429,45 @@ def main(argv):
                          }
                         )
 
+    # register HTTP Metrics API endpoint
+    # if args.get('httpMetrics', True):  # Default to True
+        # Initialize metrics collector with configuration
+        # from http_metrics import get_metrics_collector
+        # max_history = args.get('httpMetricsMaxHistory', 1000)
+        # retention_seconds = args.get('httpMetricsRetentionSeconds', 3600)
+
+    # register HTTP Metrics API endpoint
+    if analytics.http_metrics_enabled:
+        # Get or create collector with configured parameters
+        max_history = 1000
+        retention_seconds = 3600
+        cleanup_interval = 300  # 5 minutes
+        collector = get_metrics_collector()
+        collector.max_history = max_history
+        collector.retention_seconds = retention_seconds
+        collector.cleanup_interval = cleanup_interval
+        collector.metrics = __import__('collections').deque(maxlen=max_history)
+
+        http_metrics_api = HTTPMetricsAPI(logger)
+        cherrypy.tree.mount(http_metrics_api, '/http_metrics',
+                            {'/':
+                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                             }
+                            )
+        cherrypy.tree.mount(http_metrics_api, '/internal_stats',
+                            {'/':
+                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                             }
+                            )
+        cherrypy.tree.mount(http_metrics_api, '/bundle_ids',
+                            {'/':
+                             {'request.dispatch': cherrypy.dispatch.MethodDispatcher()}
+                             }
+                            )
+
+        registered_apps.append("HTTP Metrics API for monitoring request/response data transfer")
+        logger.info(f"HTTP Metrics enabled: max_history={max_history}, retention={retention_seconds}s, cleanup_interval={cleanup_interval}s")
+
     logger.info("%s", MSG['sysStart'].format(sys.version, cherrypy.__version__))
 
     try:
@@ -438,6 +478,10 @@ def main(argv):
         refresher = TopoRefreshManager(refresh_metadata, refresh_all=False)
         cherrypy.engine.subscribe('start', refresher.start_monitor)
         cherrypy.engine.subscribe('stop', refresher.stop_monitor)
+        if analytics.http_metrics_enabled:
+            # Subscribe HTTP metrics cleanup to engine lifecycle
+            cherrypy.engine.subscribe('start', collector.start_periodic_cleanup)
+            cherrypy.engine.subscribe('stop', collector.stop_periodic_cleanup)
         cherrypy.engine.start()
         cherrypy.engine.log('test')
         logger.info("%s", MSG['ConnApplications'].format(",\n ".join(registered_apps))

--- a/source/zimonGrafanaIntf.py
+++ b/source/zimonGrafanaIntf.py
@@ -430,11 +430,11 @@ def main(argv):
                         )
 
     # register HTTP Metrics API endpoint
-    # if args.get('httpMetrics', True):  # Default to True
-        # Initialize metrics collector with configuration
-        # from http_metrics import get_metrics_collector
-        # max_history = args.get('httpMetricsMaxHistory', 1000)
-        # retention_seconds = args.get('httpMetricsRetentionSeconds', 3600)
+    # if args.get('httpMetrics', True):
+    #     Initialize metrics collector with configuration
+    #     from http_metrics import get_metrics_collector
+    #     max_history = args.get('httpMetricsMaxHistory', 1000)
+    #     retention_seconds = args.get('httpMetricsRetentionSeconds', 3600)
 
     # register HTTP Metrics API endpoint
     if analytics.http_metrics_enabled:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,316 @@
+'''
+##############################################################################
+# Copyright 2026 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+Unit tests for stats.py module
+'''
+
+import unittest
+import time
+import json
+import csv
+from io import StringIO
+from unittest import mock
+from source.stats import HTTPRequestMetric, HTTPMetricsCollector, get_metrics_collector
+
+
+class TestHTTPRequestMetric(unittest.TestCase):
+    """Test cases for HTTPRequestMetric dataclass"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.timestamp = time.time()
+        self.labels = {
+            'bundle_id': 'test_bundle_123',
+            'collector_name': 'GPFSFilesystemIO',
+            'job': 'prometheus-job1'
+        }
+        self.metrics = {
+            'PrometheusExporter_metrics': 0.234,
+            'perfmon_response_duration': 0.189,
+            'perfmon_response_amount': 1024,
+            'perfmon_response_content': 512
+        }
+        self.metric = HTTPRequestMetric(
+            timestamp=self.timestamp,
+            labels=self.labels,
+            metrics=self.metrics
+        )
+
+    def test_metric_creation(self):
+        """Test HTTPRequestMetric creation"""
+        self.assertEqual(self.metric.timestamp, self.timestamp)
+        self.assertEqual(self.metric.labels, self.labels)
+        self.assertEqual(self.metric.metrics, self.metrics)
+
+    def test_convert_bundle_to_metrics_timeseries(self):
+        """Test conversion of bundle to metrics timeseries"""
+        result = self.metric.convert_bundle_to_metrics_timeseries()
+        # Check that all metrics are present
+        self.assertEqual(len(result), len(self.metrics))
+        # Check structure of each metric
+        for metric_name, metric_value in self.metrics.items():
+            self.assertIn(metric_name, result)
+            timeseries_list = result[metric_name]
+            self.assertEqual(len(timeseries_list), 1)
+            
+            timeserie = timeseries_list[0]
+            self.assertEqual(timeserie['labels'], self.labels)
+            self.assertEqual(timeserie['value'], metric_value)
+            self.assertEqual(timeserie['timestamp'], self.timestamp)
+
+
+class TestHTTPMetricsCollector(unittest.TestCase):
+    """Test cases for HTTPMetricsCollector class"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.collector = HTTPMetricsCollector()
+        self.timestamp = time.time()
+        self.labels = {
+            'bundle_id': 'test_bundle_456',
+            'collector_name': 'GPFSPoolCap',
+            'job': 'prometheus-job2'
+        }
+        self.metrics = {
+            'PrometheusExporter_metrics': 0.156,
+            'perfmon_response_duration': 0.123
+        }
+
+    def test_collector_initialization(self):
+        """Test HTTPMetricsCollector initialization"""
+        self.assertIsNotNone(self.collector.metrics)
+        self.assertIsNotNone(self.collector.stats)
+        self.assertIsNotNone(self.collector.lock)
+        self.assertEqual(self.collector.stats['total_requests'], 0)
+
+    def test_record_metric(self):
+        """Test recording a metric"""
+        initial_count = self.collector.stats['total_requests']
+        self.collector.record_metric(self.labels, self.metrics)
+        # Check that total_requests increased
+        self.assertEqual(self.collector.stats['total_requests'], initial_count + 1)
+        self.assertEqual(len(self.collector.metrics), 1)
+
+    def test_get_recent_metrics_with_limit(self):
+        """Test getting recent metrics with limit"""
+        for i in range(10):
+            self.collector.record_metric(self.labels, self.metrics)
+
+        recent = self.collector.get_recent_metrics(limit=5)
+        self.assertEqual(len(recent), 5)
+        self.assertIsInstance(recent[0], HTTPRequestMetric)
+
+    def test_get_recent_metrics_without_limit(self):
+        """Test getting all recent metrics"""
+        # Add 3 metrics
+        for i in range(3):
+            self.collector.record_metric(self.labels, self.metrics)
+        # Get all metrics
+        recent = self.collector.get_recent_metrics()
+        self.assertEqual(len(recent), 3)
+
+    def test_get_metrics_last_5_minutes(self):
+        """Test getting metrics from last 5 minutes"""
+        self.collector.record_metric(self.labels, self.metrics)
+        # Get metrics from last 5 minutes
+        recent_metrics = self.collector.get_metrics_last_5_minutes()
+        # Should have at least the metric we just added
+        self.assertGreaterEqual(len(recent_metrics), 1)
+
+    def test_get_prometheus_metrics(self):
+        """Test Prometheus metrics format generation"""
+        self.collector.record_metric(self.labels, self.metrics)
+        lines = self.collector.get_prometheus_metrics()
+        # Check that output contains expected elements
+        output = '\n'.join(lines)
+        self.assertIn('# HELP', output)
+        self.assertIn('# TYPE', output)
+        self.assertIn('PrometheusExporter_metrics', output)
+        self.assertIn('perfmon_response_duration', output)
+        # Check that labels are included
+        self.assertIn('bundle_id="test_bundle_456"', output)
+        self.assertIn('collector_name="GPFSPoolCap"', output)
+
+    def test_get_opentsdb_format(self):
+        """Test OpenTSDB format generation via HTTPMetricsCollector"""
+        self.collector.record_metric(self.labels, self.metrics)
+        # Get metrics in OpenTSDB format
+        opentsdb_response = self.collector.get_opentsdb_metrics()
+        # Check that response is a list
+        self.assertIsInstance(opentsdb_response, list)
+        self.assertGreater(len(opentsdb_response), 0)
+        # Check structure of first response
+        first_metric = opentsdb_response[0]
+        self.assertIn('metric', first_metric)
+        self.assertIn('tags', first_metric)
+        self.assertIn('dps', first_metric)
+        # Check that tags match our labels
+        self.assertEqual(first_metric['tags'], self.labels)
+        # Check that dps is a dict with timestamp keys
+        self.assertIsInstance(first_metric['dps'], dict)
+        self.assertGreater(len(first_metric['dps']), 0)
+
+    def test_get_opentsdb_format_with_aggregated_tags(self):
+        """Test OpenTSDB format generation with aggregated tags"""
+        self.collector.record_metric(self.labels, self.metrics)
+        aggregated_tags = ['node', 'cluster']
+        opentsdb_response = self.collector.get_opentsdb_metrics(aggregated_tags=aggregated_tags)
+        # Check that aggregatedTags is present in response
+        self.assertGreater(len(opentsdb_response), 0)
+        first_metric = opentsdb_response[0]
+        self.assertIn('aggregatedTags', first_metric)
+        self.assertEqual(first_metric['aggregatedTags'], aggregated_tags)
+
+    def test_get_csv_metrics(self):
+        """Test CSV metrics format generation"""
+        # Add metrics with different label sets
+        labels1 = {'bundle_id': 'bundle1', 'collector_name': 'Collector1', 'job': 'job1'}
+        labels2 = {'bundle_id': 'bundle2', 'collector_name': 'Collector2'}  # Missing 'job'
+
+        self.collector.record_metric(labels1, self.metrics)
+        self.collector.record_metric(labels2, self.metrics)
+
+        csv_output = self.collector.get_csv_metrics()
+        reader = csv.DictReader(StringIO(csv_output))
+        rows = list(reader)
+
+        # Check header contains all expected columns
+        headers = reader.fieldnames
+        self.assertIsNotNone(headers)
+        self.assertIn('timestamp', headers)
+        self.assertIn('metric_name', headers)
+        self.assertIn('value', headers)
+        self.assertIn('bundle_id', headers)
+        self.assertIn('collector_name', headers)
+        self.assertIn('job', headers)
+
+        # Check that we have rows for all metrics
+        # 2 records * 2 metrics each = 4 rows
+        self.assertEqual(len(rows), 4)
+
+        # Check that missing labels are handled (empty string)
+        bundle2_rows = [r for r in rows if r['bundle_id'] == 'bundle2']
+        self.assertTrue(all(r['job'] == '' for r in bundle2_rows))
+
+    def test_get_csv_metrics_empty(self):
+        """Test CSV generation with no metrics"""
+        csv_output = self.collector.get_csv_metrics()
+
+        lines = csv_output.strip().split('\n')
+        self.assertEqual(len(lines), 1)  # Only header
+        self.assertIn('timestamp', lines[0])
+
+    def test_get_csv_metrics_with_limit(self):
+        """Test CSV metrics format generation with limit parameter"""
+        # Record multiple metrics
+        for i in range(5):
+            labels = self.labels.copy()
+            labels['iteration'] = str(i)
+            self.collector.record_metric(labels, self.metrics)
+        csv_content = self.collector.get_csv_metrics(limit=2)
+        self.assertIsInstance(csv_content, str)
+        self.assertGreater(len(csv_content), 0)
+        # Check for header row and limited data rows
+        lines = csv_content.strip().split('\n')
+        # Should have header + (2 metrics * number of metric keys in self.metrics)
+        # Each metric generates multiple rows (one per metric key)
+        self.assertGreater(len(lines), 1)  # At least header + some data
+        # Verify we got limited results (not all 5 iterations)
+        csv_full = self.collector.get_csv_metrics()
+        lines_full = csv_full.strip().split('\n')
+        self.assertLess(len(lines), len(lines_full))
+
+    def test_get_statistics(self):
+        """Test getting statistics"""
+
+        for i in range(5):
+            self.collector.record_metric(self.labels, self.metrics)
+
+        stats = self.collector.get_statistics()
+
+        # Check basic statistics
+        self.assertEqual(stats['total_requests'], 5)
+        self.assertEqual(stats['metrics_in_memory_count'], 5)
+        self.assertIn('metrics_in_memory_size', stats)
+        self.assertGreater(stats['metrics_in_memory_size'], 0)
+
+    def test_reset_statistics(self):
+        """Test resetting statistics"""
+
+        self.collector.record_metric(self.labels, self.metrics)
+        self.assertEqual(self.collector.stats['total_requests'], 1)
+        self.assertEqual(len(self.collector.metrics), 1)
+
+        self.collector.reset_statistics()
+
+        # Check that everything is cleared
+        self.assertEqual(self.collector.stats['total_requests'], 0)
+        self.assertEqual(len(self.collector.metrics), 0)
+
+    def test_maxlen_enforcement(self):
+        """Test that metrics deque respects maxlen"""
+
+        maxlen = 10000  # Default maxlen
+        for i in range(maxlen + 100):
+            self.collector.record_metric(self.labels, self.metrics)
+
+        self.assertLessEqual(len(self.collector.metrics), maxlen)
+
+    def test_thread_safety(self):
+        """Test that collector is thread-safe"""
+        import threading
+
+        def add_metrics():
+            for i in range(100):
+                self.collector.record_metric(self.labels, self.metrics)
+
+        # Create multiple threads
+        threads = [threading.Thread(target=add_metrics) for _ in range(5)]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        self.assertEqual(self.collector.stats['total_requests'], 500)
+
+
+class TestGetMetricsCollector(unittest.TestCase):
+    """Test cases for get_metrics_collector singleton function"""
+
+    def test_singleton_pattern(self):
+        """Test that get_metrics_collector returns the same instance"""
+        collector1 = get_metrics_collector()
+        collector2 = get_metrics_collector()
+
+        self.assertIs(collector1, collector2)
+
+    def test_collector_persistence(self):
+        """Test that collector persists data across calls"""
+        collector1 = get_metrics_collector()
+        labels = {'test': 'label'}
+        metrics = {'test_metric': 1.0}
+
+        collector1.record_metric(labels, metrics)
+
+        collector2 = get_metrics_collector()
+        self.assertEqual(collector2.stats['total_requests'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -20,10 +20,8 @@ Unit tests for stats.py module
 
 import unittest
 import time
-import json
 import csv
 from io import StringIO
-from unittest import mock
 from source.stats import HTTPRequestMetric, HTTPMetricsCollector, get_metrics_collector
 
 
@@ -66,7 +64,6 @@ class TestHTTPRequestMetric(unittest.TestCase):
             self.assertIn(metric_name, result)
             timeseries_list = result[metric_name]
             self.assertEqual(len(timeseries_list), 1)
-            
             timeserie = timeseries_list[0]
             self.assertEqual(timeserie['labels'], self.labels)
             self.assertEqual(timeserie['value'], metric_value)


### PR DESCRIPTION
This PR introduces comprehensive internal performance monitoring capabilities for the Grafana Bridge, enabling detailed tracking of HTTP request/response metrics and execution times.

Key Features:

- HTTP Metrics Collection Framework (source/stats.py, source/analytics.py)

    - New InternalMetricsCollector class for aggregating performance metrics
    - Thread-safe metric collection with automatic cleanup
    - Support for both OpenTSDB and Prometheus export formats
    - Configurable metric collection via http_metrics_enabled flag

- Prometheus & OpenTSDB Integration

    - New /internal_metrics endpoints for exposing bridge performance data
    - Metrics include request duration, response size, and execution times
    - Support for scrape job identification and filtering

- Grafana Dashboards (examples/grafana_dashboards/internal_performance_observability/)

    - "Prometheus scrape jobs execution comparison over time" dashboard
    - "Single Prometheus scrape job execution comparison over time" dashboard

- Testing (tests/test_stats.py)

    - Comprehensive unit tests for InternalMetricsCollector
    - Tests for metric aggregation, cleanup, and export formats


Impact:

  Enables self-monitoring of bridge performance
  Helps identify bottlenecks and optimize query handling
  No breaking changes to existing functionality
  Metrics collection can be toggled via configuration