### PR TITLE
 Two-File Configuration Split Support

### DIFF
--- a/source/confParser.py
+++ b/source/confParser.py
@@ -156,6 +156,11 @@ def merge_defaults_and_args(defaults, args):
 class ConfigManager(object, metaclass=Singleton):
     ''' A singleton class managing the application configuration defaults '''
 
+    # Well-known path for the customer override file on bare-metal RPM installs.
+    # Used as a fallback in parse_defaults() when no --configFile argument was
+    # supplied AND the file actually exists on disk.
+    DEFAULT_CUSTOM_CONFIG = "/etc/grafanabridge/config.ini"
+
     def __init__(self, custom_config_file=None):
         self.__defaults = {}
         self.customFile = custom_config_file
@@ -215,15 +220,18 @@ class ConfigManager(object, metaclass=Singleton):
         file (.config.ini)
         """
 
-        default_sections, defaults = self.parse_file(self.templateFile)
-        if not self.customFile or self.customFile == self.templateFile:
+        _, defaults = self.parse_file(self.templateFile)
+
+        # Determine the effective custom file
+        effective_custom = self.customFile or (
+            self.DEFAULT_CUSTOM_CONFIG
+            if os.path.isfile(self.DEFAULT_CUSTOM_CONFIG)
+            else None
+        )
+        if not effective_custom or effective_custom == self.templateFile:
             return defaults
 
-        custom_sections, customs = self.parse_file(self.customFile)
-        sect = default_sections.intersection(custom_sections)
-        if not sect:
-            return defaults
-
+        _, customs = self.parse_file(effective_custom)
         defaults.update(customs)
         return defaults
 

--- a/tests/test_configManager.py
+++ b/tests/test_configManager.py
@@ -222,13 +222,16 @@ def test_case18():
 def test_case19():
     """When /etc/grafanabridge/config.ini does not exist, ConfigManager()
     returns template-only defaults without printing an error."""
-    import unittest.mock as mock
     cm = ConfigManager.__new__(ConfigManager)
     cm._ConfigManager__defaults = {}
     cm.customFile = None
     cm.templateFile = cm.get_template_path()
-    with mock.patch('os.path.isfile', return_value=False):
+    # Point DEFAULT_CUSTOM_CONFIG at a path that is guaranteed not to exist
+    cm.__class__.DEFAULT_CUSTOM_CONFIG = '/tmp/__nonexistent_grafanabridge_test__.ini'
+    try:
         result = cm.parse_defaults()
+    finally:
+        cm.__class__.DEFAULT_CUSTOM_CONFIG = '/etc/grafanabridge/config.ini'
     # Template defaults returned; no key from a non-existent override file
     assert isinstance(result, dict)
     assert len(result) > 0

--- a/tests/test_configManager.py
+++ b/tests/test_configManager.py
@@ -173,3 +173,81 @@ def test_case16():
         assert result['query']['includeDiskData'] is True
     finally:
         os.unlink(tmp_ini)
+
+
+def test_case17():
+    """A custom file containing only [server] overrides server keys;
+    all other defaults come from the template."""
+    import tempfile
+    content = "[server]\nserver = testhost.example.com\n"
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+        f.write(content)
+        tmp = f.name
+    try:
+        cm = ConfigManager.__new__(ConfigManager)
+        cm._ConfigManager__defaults = {}
+        cm.customFile = tmp
+        cm.templateFile = cm.get_template_path()
+        result = cm.parse_defaults()
+        # Override applied
+        assert result['server'] == 'testhost.example.com'
+        # Unrelated template default still present
+        assert result['serverPort'] == 9980
+    finally:
+        os.unlink(tmp)
+
+
+def test_case18():
+    """Section-intersection guard is gone: a custom file with a locally-added
+    section (not in template) must not cause the file to be silently dropped."""
+    import tempfile
+    content = "[local_extension]\ncustomKey = customValue\n"
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+        f.write(content)
+        tmp = f.name
+    try:
+        cm = ConfigManager.__new__(ConfigManager)
+        cm._ConfigManager__defaults = {}
+        cm.customFile = tmp
+        cm.templateFile = cm.get_template_path()
+        result = cm.parse_defaults()
+        # Local key present
+        assert result.get('customKey') == 'customValue'
+        # Template defaults also present (file was not silently dropped)
+        assert result['serverPort'] == 9980
+    finally:
+        os.unlink(tmp)
+
+
+def test_case19():
+    """When /etc/grafanabridge/config.ini does not exist, ConfigManager()
+    returns template-only defaults without printing an error."""
+    import unittest.mock as mock
+    cm = ConfigManager.__new__(ConfigManager)
+    cm._ConfigManager__defaults = {}
+    cm.customFile = None
+    cm.templateFile = cm.get_template_path()
+    with mock.patch('os.path.isfile', return_value=False):
+        result = cm.parse_defaults()
+    # Template defaults returned; no key from a non-existent override file
+    assert isinstance(result, dict)
+    assert len(result) > 0
+
+
+def test_case20():
+    """An explicit customFile argument is used as-is; DEFAULT_CUSTOM_CONFIG
+    is never consulted even if /etc/grafanabridge/config.ini exists."""
+    import tempfile
+    content = "[server]\nserver = explicit-host\n"
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+        f.write(content)
+        tmp = f.name
+    try:
+        cm = ConfigManager.__new__(ConfigManager)
+        cm._ConfigManager__defaults = {}
+        cm.customFile = tmp    # explicit — DEFAULT_CUSTOM_CONFIG not reached
+        cm.templateFile = cm.get_template_path()
+        result = cm.parse_defaults()
+        assert result['server'] == 'explicit-host'
+    finally:
+        os.unlink(tmp)


### PR DESCRIPTION
resolves #442 

The old code required the custom file to share at least one section name with the template. Under the new split model the customer file can contain only a section that doesn't exist in the template (e.g. [local_extension]), causing the intersection to be empty and the entire customer file to be silently ignored.

Fix: the three guard lines are removed. defaults.update(customs) with an empty customs is already a no-op, so no guard was ever needed.

Because ConfigManager is a Singleton, any code path that constructs it without a customFile argument (e.g. a REST API server, future modules, or tests) gets self.customFile = None and template-only defaults, even when /etc/grafanabridge/config.ini exists on disk.

Fix: a class constant [DEFAULT_CUSTOM_CONFIG =](vscode-webview://0ulk4f5c3v2q9qcck826bulcf3ie1n6doghl7etrgrb7tvcn71uk/source/confParser.py:162)